### PR TITLE
[ovsp4rt] Implement GetTxAccVsiPort()

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -2110,6 +2110,49 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
   return client.sendReadRequest(read_request);
 }
 
+absl::StatusOr<uint32> GetTxAccVsiPort(ClientInterface& client,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       uint32 src_port) {
+  auto response_or_status = GetTxAccVsiTableEntry(client, src_port, p4info);
+  auto status = response_or_status.status();
+  if (!status.ok()) return status;
+
+  ::p4::v1::ReadResponse read_response = std::move(response_or_status).value();
+
+  // TODO(derek): remove dead code
+  std::vector<::p4::v1::TableEntry> table_entries;
+  table_entries.reserve(read_response.entities().size());
+
+  int param_id =
+      GetParamId(p4info, TX_ACC_VSI_TABLE_ACTION_L2_FWD_AND_BYPASS_BRIDGE,
+                 ACTION_L2_FWD_AND_BYPASS_BRIDGE_PARAM_PORT);
+
+  uint32_t host_sp = 0;
+  for (const auto& entity : read_response.entities()) {
+    ::p4::v1::TableEntry table_entry = entity.table_entry();
+    // TODO(derek): why mutable?
+    auto* table_action = table_entry.mutable_action();
+    // TODO(derek): why mutable?
+    auto* action = table_action->mutable_action();
+    // TODO(derek): validate table_action->preamble.id?
+    for (const auto& param : action->params()) {
+      if (param_id == param.param_id()) {
+        const std::string& s1 = param.value();
+        // TODO(derek): why make a mutable copy?
+        std::string s2 = s1;
+        for (int param_bytes = 0; param_bytes < 4; param_bytes++) {
+          host_sp = host_sp << 8 | int(s2[param_bytes]);
+        }
+        // TODO(derek): This break exits to the outermost for loop,
+        // advancing to the next table entry. Is this correct?
+        // Would `return host_sp` be better?
+        break;
+      }
+    }
+  }
+  return host_sp;
+}
+
 absl::Status ConfigureVsiSrcPortTableEntry(
     ClientInterface& client, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -2269,7 +2312,7 @@ absl::Status DoConfigFdbEntry(ClientInterface& client,
           GetFdbTunnelTableEntry(client, learn_info, p4info, true);
       if (status_or_read_response.ok()) {
         // Return if entry already exists.
-        return status_or_read_response.status();
+        return util::OkStatus();
       }
     }
 
@@ -2293,45 +2336,11 @@ absl::Status DoConfigFdbEntry(ClientInterface& client,
       // Ignore errors (why?)
       (void)ConfigFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
 
-      // TODO(derek): refactor (extract method)
-      //
-      // GetVsiSrcPort(ClientInterface& client, const P4Info& p4info,
-      //               uint32_t src_port, uint32_t& vsi_port);
-      auto response_or_status =
-          GetTxAccVsiTableEntry(client, learn_info.src_port, p4info);
-      if (!response_or_status.ok()) {
-        return response_or_status.status();
+      auto host_sp = GetTxAccVsiPort(client, p4info, learn_info.src_port);
+      if (!host_sp.ok()) {
+        return host_sp.status();
       }
-
-      ::p4::v1::ReadResponse read_response =
-          std::move(response_or_status).value();
-      std::vector<::p4::v1::TableEntry> table_entries;
-
-      table_entries.reserve(read_response.entities().size());
-
-      int param_id =
-          GetParamId(p4info, TX_ACC_VSI_TABLE_ACTION_L2_FWD_AND_BYPASS_BRIDGE,
-                     ACTION_L2_FWD_AND_BYPASS_BRIDGE_PARAM_PORT);
-
-      uint32_t host_sp = 0;
-      for (const auto& entity : read_response.entities()) {
-        p4::v1::TableEntry table_entry_1 = entity.table_entry();
-        auto* table_action = table_entry_1.mutable_action();
-        auto* action = table_action->mutable_action();
-        for (const auto& param : action->params()) {
-          if (param_id == param.param_id()) {
-            const std::string& s1 = param.value();
-            std::string s2 = s1;
-            for (int param_bytes = 0; param_bytes < 4; param_bytes++) {
-              host_sp = host_sp << 8 | int(s2[param_bytes]);
-            }
-            break;
-          }
-        }
-      }
-
-      learn_info.src_port = host_sp;
-      // end of refactoring
+      learn_info.src_port = host_sp.value();
     }
 
     // Ignore errors (why?)
@@ -2414,42 +2423,11 @@ absl::Status DoConfigSrcPortEntry(ClientInterface& client,
   status = client.getPipelineConfig(&p4info);
   if (!status.ok()) return status;
 
-  // TODO(derek): refactor (extract method)
-  //
-  // GetVsiSrcPort(ClientInterface& client, const P4Info& p4info,
-  //               uint32_t src_port, uint32_t& vsi_port);
-  auto response_or_status =
-      GetTxAccVsiTableEntry(client, vsi_sp.src_port, p4info);
-  if (!response_or_status.ok()) return response_or_status.status();
-
-  ::p4::v1::ReadResponse read_response = std::move(response_or_status).value();
-  std::vector<::p4::v1::TableEntry> table_entries;
-
-  table_entries.reserve(read_response.entities().size());
-
-  int param_id =
-      GetParamId(p4info, TX_ACC_VSI_TABLE_ACTION_L2_FWD_AND_BYPASS_BRIDGE,
-                 ACTION_L2_FWD_AND_BYPASS_BRIDGE_PARAM_PORT);
-
-  uint32_t host_sp = 0;
-  for (const auto& entity : read_response.entities()) {
-    p4::v1::TableEntry table_entry_1 = entity.table_entry();
-    auto* table_action = table_entry_1.mutable_action();
-    auto* action = table_action->mutable_action();
-    for (const auto& param : action->params()) {
-      if (param_id == param.param_id()) {
-        const std::string& s1 = param.value();
-        std::string s2 = s1;
-        for (int param_bytes = 0; param_bytes < 4; param_bytes++) {
-          host_sp = host_sp << 8 | int(s2[param_bytes]);
-        }
-        break;
-      }
-    }
+  auto host_sp = GetTxAccVsiPort(client, p4info, vsi_sp.src_port);
+  if (!host_sp.ok()) {
+    return host_sp.status();
   }
-
-  vsi_sp.src_port = host_sp;
-  // end of refactoring
+  vsi_sp.src_port = host_sp.value();
 
   return ConfigureVsiSrcPortTableEntry(client, vsi_sp, p4info, insert_entry);
 }

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -1,4 +1,5 @@
 // Copyright 2022-2025 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 // Revision of ovsp4rt.cc to improve testability.


### PR DESCRIPTION
- Extracted the `GetTxAccVsiPort()` function from `ConfigFdbEntry()` and `ConfigSrcPortEntry()`.

This CL is ES2K-specific. Only ES2K functions call `GetTxAccVsiPort`.

> [!NOTE]
> The purpose of this PR is to *refactor*. I propose to make the mutability changes noted in the comments in a second PR, and any other changes in subsequent PRs.