### PR TITLE
[ovsp4rt] Encode P4Runtime actions

### DIFF
--- a/ovs-p4rt/sidecar/journal/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/journal/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMake build file for ovs-p4rt/sidecar/journal
 #
 # Copyright 2024 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -13,8 +14,10 @@ set_property(DIRECTORY PROPERTY LABELS ovsp4rt)
 # ovsp4rt_journal_o
 #-----------------------------------------------------------------------
 add_library(ovsp4rt_journal_o OBJECT
-  ovsp4rt_encode.cc
-  ovsp4rt_encode.h
+  ovsp4rt_encode_actions.cc
+  ovsp4rt_encode_actions.h
+  ovsp4rt_encode_inputs.cc
+  ovsp4rt_encode_inputs.h
   ovsp4rt_journal.cc
   ovsp4rt_journal.h
 )
@@ -36,8 +39,8 @@ if(BUILD_TESTING)
 add_executable(encode_addr_test
   encode_addr_test.cc
   encode_base_test.h
-  ovsp4rt_encode.cc
-  ovsp4rt_encode.h
+  ovsp4rt_encode_inputs.cc
+  ovsp4rt_encode_inputs.h
   test_main.cc
 )
 

--- a/ovs-p4rt/sidecar/journal/encode_addr_test.cc
+++ b/ovs-p4rt/sidecar/journal/encode_addr_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 #include <arpa/inet.h>
@@ -10,7 +11,7 @@
 #include "encode_base_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_encode.h"
+#include "ovsp4rt_encode_inputs.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ovsp4rt_encode_actions.h"

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
@@ -1,0 +1,69 @@
+// Copyright 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_encode_actions.h"
+
+#include <nlohmann/json.hpp>
+
+#include "p4/v1/p4runtime.pb.h"
+
+namespace {
+constexpr uint32_t READ_REQUEST_VERSION = 0;
+constexpr uint32_t READ_RESPONSE_VERSION = 0;
+constexpr uint32_t WRITE_REQUEST_VERSION = 0;
+constexpr uint32_t WRITE_STATUS_VERSION = 0;
+}  // namespace
+
+namespace ovsp4rt {
+
+nlohmann::json EncodeReadRequest(const ::p4::v1::ReadRequest& request) {
+  nlohmann::json json;
+
+  json["action"] = "ReadRequest";
+  json["version"] = READ_REQUEST_VERSION;
+
+  auto& payload = json["request"];
+  // TODO(derek): encode request
+
+  return json;
+}
+
+nlohmann::json EncodeReadResponse(
+    const absl::StatusOr<::p4::v1::ReadResponse>& response) {
+  nlohmann::json json;
+
+  json["action"] = "ReadResponse";
+  json["version"] = READ_RESPONSE_VERSION;
+
+  auto& payload = json["response"];
+  // TODO(derek): encode response.status();
+  // TODO(derek): encode response.value();
+
+  return json;
+}
+
+nlohmann::json EncodeWriteRequest(const ::p4::v1::WriteRequest& request) {
+  nlohmann::json json;
+
+  json["action"] = "WriteRequest";
+  json["version"] = WRITE_REQUEST_VERSION;
+
+  auto& payload = json["request"];
+  // TODO(derek): encode request
+
+  return json;
+}
+
+nlohmann::json EncodeWriteStatus(const absl::Status& status) {
+  nlohmann::json json;
+
+  json["action"] = "WriteStatus";
+  json["version"] = WRITE_STATUS_VERSION;
+
+  auto& payload = json["status"];
+  // TODO(derek): encode status
+
+  return json;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.h
@@ -1,0 +1,28 @@
+// Copyright 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_ENCODE_ACTIONS_H
+#define OVSP4RT_ENCODE_ACTIONS_H
+
+#include <nlohmann/json.hpp>
+
+#include "p4/v1/p4runtime.pb.h"
+
+namespace ovsp4rt {
+
+//----------------------------------------------------------------------
+// Return JSON representation of P4Runtime actions.
+//----------------------------------------------------------------------
+
+extern nlohmann::json EncodeReadRequest(const ::p4::v1::ReadRequest& request);
+
+extern nlohmann::json EncodeReadResponse(
+    const absl::StatusOr<::p4::v1::ReadResponse>& response);
+
+extern nlohmann::json EncodeWriteRequest(const ::p4::v1::WriteRequest& request);
+
+extern nlohmann::json EncodeWriteStatus(const absl::Status& status);
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_ENCODE_ACTIONS_H

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.h
@@ -1,4 +1,4 @@
-// Copyright 2025 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef OVSP4RT_ENCODE_ACTIONS_H

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_inputs.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_inputs.cc
@@ -1,7 +1,8 @@
 // Copyright 2024 Intel Corporation.
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ovsp4rt_encode.h"
+#include "ovsp4rt_encode_inputs.h"
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_inputs.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_inputs.h
@@ -1,8 +1,9 @@
 // Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OVSP4RT_ENCODE_H
-#define OVSP4RT_ENCODE_H
+#ifndef OVSP4RT_ENCODE_INPUTS_H
+#define OVSP4RT_ENCODE_INPUTS_H
 
 #include <stdbool.h>
 
@@ -69,4 +70,4 @@ extern nlohmann::json EncodeVlanId(const char* func_name, uint16_t vlan_id,
 
 }  // namespace ovsp4rt
 
-#endif  // OVSP4RT_ENCODE_H
+#endif  // OVSP4RT_ENCODE_INPUTS_H

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
@@ -10,39 +10,39 @@
 namespace ovsp4rt {
 
 // mac_learning_info
-void Journal::recordInput(const char* func_name,
-                          const struct mac_learning_info& info,
-                          bool insert_entry) {
-  auto input = EncodeMacLearningInfo(func_name, info, insert_entry);
-  journalInput(input);
+void Journal::recordInputs(const char* func_name,
+                           const struct mac_learning_info& info,
+                           bool insert_entry) {
+  auto inputs = EncodeMacLearningInfo(func_name, info, insert_entry);
+  journalInputs(inputs);
 }
 
 // ip_mac_map_info
-void Journal::recordInput(const char* func_name, const ip_mac_map_info& info,
-                          bool insert_entry) {
-  auto input = EncodeIpMacMapInfo(func_name, info, insert_entry);
-  journalInput(input);
+void Journal::recordInputs(const char* func_name, const ip_mac_map_info& info,
+                           bool insert_entry) {
+  auto inputs = EncodeIpMacMapInfo(func_name, info, insert_entry);
+  journalInputs(inputs);
 }
 
 // tunnel_info
-void Journal::recordInput(const char* func_name, const tunnel_info& info,
-                          bool insert_entry) {
-  auto input = EncodeTunnelInfo(func_name, info, insert_entry);
-  journalInput(input);
+void Journal::recordInputs(const char* func_name, const tunnel_info& info,
+                           bool insert_entry) {
+  auto inputs = EncodeTunnelInfo(func_name, info, insert_entry);
+  journalInputs(inputs);
 }
 
 // src_port_info
-void Journal::recordInput(const char* func_name, const src_port_info info,
-                          bool insert_entry) {
-  auto input = EncodeSrcPortInfo(func_name, info, insert_entry);
-  journalInput(input);
+void Journal::recordInputs(const char* func_name, const src_port_info info,
+                           bool insert_entry) {
+  auto inputs = EncodeSrcPortInfo(func_name, info, insert_entry);
+  journalInputs(inputs);
 }
 
 // vlan_id
-void Journal::recordInput(const char* func_name, uint16_t vlan_id,
-                          bool insert_entry) {
-  auto input = EncodeVlanId(func_name, vlan_id, insert_entry);
-  journalInput(input);
+void Journal::recordInputs(const char* func_name, uint16_t vlan_id,
+                           bool insert_entry) {
+  auto inputs = EncodeVlanId(func_name, vlan_id, insert_entry);
+  journalInputs(inputs);
 }
 
 void Journal::recordReadRequest(const ::p4::v1::ReadRequest& request) {
@@ -70,7 +70,7 @@ void Journal::recordWriteStatus(const absl::Status& status) {
   journalAction(action);
 }
 
-void Journal::journalInput(nlohmann::json& json) {
+void Journal::journalInputs(nlohmann::json& json) {
   // TODO(derek): to be implemented.
 }
 

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
@@ -1,9 +1,11 @@
 // Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ovsp4rt_journal.h"
 
-#include "ovsp4rt_encode.h"
+#include "ovsp4rt_encode_actions.h"
+#include "ovsp4rt_encode_inputs.h"
 
 namespace ovsp4rt {
 
@@ -11,48 +13,69 @@ namespace ovsp4rt {
 void Journal::recordInput(const char* func_name,
                           const struct mac_learning_info& info,
                           bool insert_entry) {
-  input_ = EncodeMacLearningInfo(func_name, info, insert_entry);
+  auto input = EncodeMacLearningInfo(func_name, info, insert_entry);
+  journalInput(input);
 }
 
 // ip_mac_map_info
 void Journal::recordInput(const char* func_name, const ip_mac_map_info& info,
                           bool insert_entry) {
-  input_ = EncodeIpMacMapInfo(func_name, info, insert_entry);
+  auto input = EncodeIpMacMapInfo(func_name, info, insert_entry);
+  journalInput(input);
 }
 
 // tunnel_info
 void Journal::recordInput(const char* func_name, const tunnel_info& info,
                           bool insert_entry) {
-  input_ = EncodeTunnelInfo(func_name, info, insert_entry);
+  auto input = EncodeTunnelInfo(func_name, info, insert_entry);
+  journalInput(input);
 }
 
 // src_port_info
 void Journal::recordInput(const char* func_name, const src_port_info info,
                           bool insert_entry) {
-  input_ = EncodeSrcPortInfo(func_name, info, insert_entry);
+  auto input = EncodeSrcPortInfo(func_name, info, insert_entry);
+  journalInput(input);
 }
 
 // vlan_id
 void Journal::recordInput(const char* func_name, uint16_t vlan_id,
                           bool insert_entry) {
-  input_ = EncodeVlanId(func_name, vlan_id, insert_entry);
+  auto input = EncodeVlanId(func_name, vlan_id, insert_entry);
+  journalInput(input);
 }
 
 void Journal::recordReadRequest(const ::p4::v1::ReadRequest& request) {
-  // TODO(derek): to be implemented. Add func_name parameter?
+  // TODO(derek): Add func_name parameter?
+  auto action = EncodeReadRequest(request);
+  journalAction(action);
 }
 
 void Journal::recordReadResponse(
     const absl::StatusOr<::p4::v1::ReadResponse>& response) {
-  // TODO(derek): to be implemented. Add func_name parameter?
+  // TODO(derek): Add func_name parameter?
+  auto action = EncodeReadResponse(response);
+  journalAction(action);
 }
 
 void Journal::recordWriteRequest(const ::p4::v1::WriteRequest& request) {
-  // TODO(derek): to be implemented. Add func_name parameter?
+  // TODO(derek): Add func_name parameter?
+  auto action = EncodeWriteRequest(request);
+  journalAction(action);
 }
 
 void Journal::recordWriteStatus(const absl::Status& status) {
-  // TODO(derek): to be implemented. Add func_name parameter?
+  // TODO(derek): Add func_name parameter?
+  auto action = EncodeWriteStatus(status);
+  journalAction(action);
+}
+
+void Journal::journalInput(nlohmann::json& json) {
+  // TODO(derek): to be implemented.
+}
+
+void Journal::journalAction(nlohmann::json& json) {
+  // TODO(derek): to be implemented.
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
@@ -21,19 +21,19 @@ class Journal {
  public:
   ~Journal() { saveEntry(); }
 
-  void recordInput(const char* func_name, const struct mac_learning_info& info,
-                   bool insert_entry);
+  void recordInputs(const char* func_name, const struct mac_learning_info& info,
+                    bool insert_entry);
 
-  void recordInput(const char* func_name, const ip_mac_map_info& info,
-                   bool insert_entry);
+  void recordInputs(const char* func_name, const ip_mac_map_info& info,
+                    bool insert_entry);
 
-  void recordInput(const char* func_name, const tunnel_info& info,
-                   bool insert_entry);
+  void recordInputs(const char* func_name, const tunnel_info& info,
+                    bool insert_entry);
 
-  void recordInput(const char* func_name, const src_port_info info,
-                   bool insert_entry);
+  void recordInputs(const char* func_name, const src_port_info info,
+                    bool insert_entry);
 
-  void recordInput(const char* func_name, uint16_t vlan_id, bool insert_entry);
+  void recordInputs(const char* func_name, uint16_t vlan_id, bool insert_entry);
 
   void recordReadRequest(const ::p4::v1::ReadRequest& request);
 
@@ -47,7 +47,7 @@ class Journal {
   void saveEntry() {}
 
  protected:
-  void journalInput(nlohmann::json& json);
+  void journalInputs(nlohmann::json& json);
 
   void journalAction(nlohmann::json& json);
 

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
@@ -1,4 +1,5 @@
 // Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef OVSP4RT_JOURNAL_H_
@@ -45,9 +46,14 @@ class Journal {
 
   void saveEntry() {}
 
+ protected:
+  void journalInput(nlohmann::json& json);
+
+  void journalAction(nlohmann::json& json);
+
  private:
   nlohmann::json input_;
-  std::vector<nlohmann::json> output_;
+  std::vector<nlohmann::json> actions_;
 };
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
@@ -16,7 +16,7 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, learn_info, insert_entry);
+  client.journal().recordInputs(__func__, learn_info, insert_entry);
 
   (void)DoConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
 }
@@ -29,7 +29,7 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, tunnel_info, insert_entry);
+  client.journal().recordInputs(__func__, tunnel_info, insert_entry);
 
   (void)DoConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
 }
@@ -67,7 +67,7 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, ip_info, insert_entry);
+  client.journal().recordInputs(__func__, ip_info, insert_entry);
 
   (void)DoConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
 }
@@ -81,7 +81,7 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, tunnel_info, insert_entry);
+  client.journal().recordInputs(__func__, tunnel_info, insert_entry);
 
   (void)DoConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
 }
@@ -94,7 +94,7 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, vsi_sp, insert_entry);
+  client.journal().recordInputs(__func__, vsi_sp, insert_entry);
 
   (void)DoConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
 }
@@ -108,7 +108,7 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, tnl_sp, insert_entry);
+  client.journal().recordInputs(__func__, tnl_sp, insert_entry);
 
   (void)DoConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
 }
@@ -121,7 +121,7 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, vlan_id, insert_entry);
+  client.journal().recordInputs(__func__, vlan_id, insert_entry);
 
   (void)DoConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
 }


### PR DESCRIPTION
Continued development of Journal code.
- Renamed `ovsp4rt_encode.{cc,h}` to `ovsp4rt_encode_inputs.{cc,h}`.
- Renamed `recordInput()` to `recordInputs()`.
- Implemented `ovsp4rt_encode_action.{cc,h}`.
- Roughed-in `journalInput()` and `journalAction()`.