### PR TITLE
[ovsp4rt] Finish initial Journal implementation

### DIFF
--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
@@ -3,8 +3,11 @@
 
 #include "ovsp4rt_encode_actions.h"
 
+#include <google/protobuf/util/json_util.h>
+
 #include <nlohmann/json.hpp>
 
+#include "absl/status/statusor.h"
 #include "p4/v1/p4runtime.pb.h"
 
 namespace {
@@ -16,14 +19,39 @@ constexpr uint32_t WRITE_STATUS_VERSION = 0;
 
 namespace ovsp4rt {
 
+// These functions are only used by this module.
+// They can be exposed if the need arises.
+
+namespace {
+
+nlohmann::json EncodeStatus(const absl::Status& status) {
+  return {{"code", static_cast<int>(status.code())},
+          {"message",
+           // Convert absl::string_view to std::string
+           std::string(status.message())}};
+}
+
+nlohmann::json EncodeProtobuf(const google::protobuf::Message& message) {
+  std::string jsonString;
+  auto status =
+      google::protobuf::util::MessageToJsonString(message, &jsonString);
+  if (status.ok()) {
+    return nlohmann::json::parse(jsonString);
+  } else {
+    // There may be a better way to report the conversion error.
+    // Try this for now.
+    return {{"EncodeProtobuf", EncodeStatus(status)}};
+  }
+}
+
+}  // namespace
+
 nlohmann::json EncodeReadRequest(const ::p4::v1::ReadRequest& request) {
   nlohmann::json json;
 
   json["action"] = "ReadRequest";
   json["version"] = READ_REQUEST_VERSION;
-
-  auto& payload = json["request"];
-  // TODO(derek): encode request
+  json["message"] = EncodeProtobuf(request);
 
   return json;
 }
@@ -35,9 +63,11 @@ nlohmann::json EncodeReadResponse(
   json["action"] = "ReadResponse";
   json["version"] = READ_RESPONSE_VERSION;
 
-  auto& payload = json["response"];
-  // TODO(derek): encode response.status();
-  // TODO(derek): encode response.value();
+  if (response.ok()) {
+    json["message"] = EncodeProtobuf(response.value());
+  } else {
+    json["status"] = EncodeStatus(response.status());
+  }
 
   return json;
 }
@@ -47,9 +77,7 @@ nlohmann::json EncodeWriteRequest(const ::p4::v1::WriteRequest& request) {
 
   json["action"] = "WriteRequest";
   json["version"] = WRITE_REQUEST_VERSION;
-
-  auto& payload = json["request"];
-  // TODO(derek): encode request
+  json["message"] = EncodeProtobuf(request);
 
   return json;
 }
@@ -59,9 +87,7 @@ nlohmann::json EncodeWriteStatus(const absl::Status& status) {
 
   json["action"] = "WriteStatus";
   json["version"] = WRITE_STATUS_VERSION;
-
-  auto& payload = json["status"];
-  // TODO(derek): encode status
+  json["status"] = EncodeStatus(status);
 
   return json;
 }

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
@@ -4,10 +4,16 @@
 
 #include "ovsp4rt_journal.h"
 
+#include <iostream>
+
 #include "ovsp4rt_encode_actions.h"
 #include "ovsp4rt_encode_inputs.h"
 
 namespace ovsp4rt {
+
+//----------------------------------------------------------------------
+// Record API interactions
+//----------------------------------------------------------------------
 
 // mac_learning_info
 void Journal::recordInputs(const char* func_name,
@@ -45,6 +51,10 @@ void Journal::recordInputs(const char* func_name, uint16_t vlan_id,
   journalInputs(inputs);
 }
 
+//----------------------------------------------------------------------
+// Record P4Runtime interactions
+//----------------------------------------------------------------------
+
 void Journal::recordReadRequest(const ::p4::v1::ReadRequest& request) {
   // TODO(derek): Add func_name parameter?
   auto action = EncodeReadRequest(request);
@@ -70,12 +80,16 @@ void Journal::recordWriteStatus(const absl::Status& status) {
   journalAction(action);
 }
 
+//----------------------------------------------------------------------
+// Record interactions in journal
+//----------------------------------------------------------------------
+
 void Journal::journalInputs(nlohmann::json& json) {
-  // TODO(derek): to be implemented.
+  std::cout << "inputs: " << json.dump(4) << std::endl;
 }
 
 void Journal::journalAction(nlohmann::json& json) {
-  // TODO(derek): to be implemented.
+  std::cout << "actions: " << json.dump(4) << std::endl;
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
@@ -1,4 +1,5 @@
-// Copyright 2022-2025 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 // Journaling implementation of the ovsp4rt C API.
@@ -18,7 +19,7 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   JournalClient client;
   client.journal().recordInputs(__func__, learn_info, insert_entry);
 
-  (void)DoConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
+  DoConfigFdbEntry(client, learn_info, insert_entry, grpc_addr).IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -31,7 +32,8 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   JournalClient client;
   client.journal().recordInputs(__func__, tunnel_info, insert_entry);
 
-  (void)DoConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr)
+      .IgnoreError();
 }
 
 #if defined(DPDK_TARGET)
@@ -69,7 +71,7 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
   JournalClient client;
   client.journal().recordInputs(__func__, ip_info, insert_entry);
 
-  (void)DoConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
+  DoConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr).IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -83,7 +85,8 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
   JournalClient client;
   client.journal().recordInputs(__func__, tunnel_info, insert_entry);
 
-  (void)DoConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr)
+      .IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -96,7 +99,7 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
   JournalClient client;
   client.journal().recordInputs(__func__, vsi_sp, insert_entry);
 
-  (void)DoConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
+  DoConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr).IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -110,7 +113,8 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
   JournalClient client;
   client.journal().recordInputs(__func__, tnl_sp, insert_entry);
 
-  (void)DoConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
+  DoConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr)
+      .IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -123,7 +127,7 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
   JournalClient client;
   client.journal().recordInputs(__func__, vlan_id, insert_entry);
 
-  (void)DoConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
+  DoConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr).IgnoreError();
 }
 
 #endif  // ES2K_TARGET

--- a/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
@@ -1,4 +1,5 @@
-// Copyright 2022-2025 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 // Standard implementation of the ovsp4rt C API.
@@ -17,7 +18,7 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
 
   Client client;
 
-  (void)DoConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
+  DoConfigFdbEntry(client, learn_info, insert_entry, grpc_addr).IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -29,7 +30,8 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
 
   Client client;
 
-  (void)DoConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr)
+      .IgnoreError();
 }
 
 #if defined(DPDK_TARGET)
@@ -66,7 +68,7 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
 
   Client client;
 
-  (void)DoConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
+  DoConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr).IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -79,7 +81,8 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
 
   Client client;
 
-  (void)DoConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr)
+      .IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -91,7 +94,7 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
 
   Client client;
 
-  (void)DoConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
+  DoConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr).IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -104,7 +107,8 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
 
   Client client;
 
-  (void)DoConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
+  DoConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr)
+      .IgnoreError();
 }
 
 //----------------------------------------------------------------------
@@ -116,7 +120,7 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
 
   Client client;
 
-  (void)DoConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
+  DoConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr).IgnoreError();
 }
 
 #endif  // ES2K_TARGET


### PR DESCRIPTION
- Added logic to record message/status for P4Runtime interactions.
- Modified the public API functions to use `.IgnoreError()` instead of `(void)` to ignore the `absl::Status` value returned by the `DoConfig` functions.
- Modified `journalInputs()` and `journalAction()` to dump events to stdout, for initial testing.