### PR TITLE
[ovsp4rt] Refine internal interface header files

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -33,13 +33,15 @@ add_library(ovs_sidecar_o OBJECT
 if(BUILD_CLIENT)
   if(BUILD_JOURNAL)
     target_sources(ovs_sidecar_o PRIVATE
-      ovsp4rt_internal_api.h
+      ovsp4rt_config_int.h
+      ovsp4rt_doconfig_int.h
       ovsp4rt_journal_api.cc
       ovsp4rt_simple_api.cc
     )
   else()
     target_sources(ovs_sidecar_o PRIVATE
-      ovsp4rt_internal_api.h
+      ovsp4rt_config_int.h
+      ovsp4rt_doconfig_int.h
       ovsp4rt_simple_api.cc
       ovsp4rt_standard_api.cc
     )

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -24,7 +24,8 @@
 #include "logging/ovsp4rt_logging.h"
 #include "logging/ovsp4rt_logutils.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_internal_api.h"
+#include "ovsp4rt_config_int.h"
+#include "ovsp4rt_doconfig_int.h"
 #include "ovsp4rt_private.h"
 
 #if defined(DPDK_TARGET)

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -1,4 +1,5 @@
-// Copyright 2022-2025 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 #include <arpa/inet.h>

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -1,0 +1,23 @@
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Defines the internal interface to the C++ ConfigEntry functions.
+
+#ifndef OVSP4RT_CONFIG_API_H_
+#define OVSP4RT_CONFIG_API_H_
+
+#include "absl/status/status.h"
+#include "client/ovsp4rt_client_interface.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "p4/v1/p4runtime.pb.h"
+
+namespace ovsp4rt {
+
+extern absl::Status ConfigFdbTxVlanTableEntry(
+    ClientInterface& client, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_CONFIG_API_H_

--- a/ovs-p4rt/sidecar/ovsp4rt_doconfig_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_doconfig_int.h
@@ -1,11 +1,12 @@
-// Copyright 2022-2025 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Defines the interface to the C++ functions that implement
-// the core logic of the ovsp4rt C API.
+// Defines the internal interface to the C++ DoConfigEntry functions,
+// which are invoked by the C API wrappers.
 
-#ifndef OVSP4RT_INTERNAL_API_H_
-#define OVSP4RT_INTERNAL_API_H_
+#ifndef OVSP4RT_DOCONFIG_API_H_
+#define OVSP4RT_DOCONFIG_API_H_
 
 #include "absl/status/status.h"
 #include "client/ovsp4rt_client_interface.h"
@@ -49,4 +50,4 @@ extern absl::Status DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
 
 }  // namespace ovsp4rt
 
-#endif  // OVSP4RT_INTERNAL_API_H_
+#endif  // OVSP4RT_DOCONFIG_API_H_

--- a/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
@@ -7,7 +7,7 @@
 
 #include "client/ovsp4rt_journal_client.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_internal_api.h"
+#include "ovsp4rt_doconfig_int.h"
 
 //----------------------------------------------------------------------
 // ovsp4rt_config_fdb_entry (DPDK, ES2K)

--- a/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
@@ -7,7 +7,7 @@
 
 #include "client/ovsp4rt_client.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_internal_api.h"
+#include "ovsp4rt_doconfig_int.h"
 
 //----------------------------------------------------------------------
 // ovsp4rt_config_fdb_entry (DPDK, ES2K)


### PR DESCRIPTION
- Renamed `ovsp4rt_internal_api.h` to `ovsp4rt_doconfig_int.h`. It exposes `DoConfigTableEntry` functions internally, for use by the C API wrappers and for unit testing.

- Added `ovsp4rt_config_int.h`. It exposes `ConfigTableEntry` functions internally, for unit testing.