### PR TITLE
[ovsp4rt] Enclose match-key assignments in blocks

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -153,10 +153,10 @@ void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
   }
   {
     // match bridge id
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(GetMatchFieldId(p4info, L2_FWD_SMAC_TABLE,
-                                         L2_FWD_SMAC_TABLE_KEY_BRIDGE_ID));
-    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, L2_FWD_SMAC_TABLE,
+                                        L2_FWD_SMAC_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
   }
 
   if (insert_entry) {
@@ -186,10 +186,10 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
 #if defined(ES2K_TARGET)
   {
     // match bridge id
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
-        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
+                                        L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
   }
 #endif
 
@@ -276,10 +276,10 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
   }
   {
     // match bridge id
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
-        GetMatchFieldId(p4info, L2_FWD_RX_TABLE, L2_FWD_RX_TABLE_KEY_BRIDGE_ID));
-    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, L2_FWD_RX_TABLE,
+                                        L2_FWD_RX_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
   }
 
   if (insert_entry) {
@@ -356,10 +356,10 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
 #if defined(ES2K_TARGET)
   {
     // match bridge id
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
-        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
+                                        L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
   }
 #endif
 
@@ -467,10 +467,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
 #if defined(ES2K_TARGET)
   {
     // match bridge id
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
-        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
+                                        L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
   }
 #endif
 
@@ -620,7 +620,7 @@ void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
   }
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
                                      const struct mac_learning_info& learn_info,
                                      const ::p4::config::v1::P4Info& p4info,
@@ -642,7 +642,7 @@ absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
   return status;
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::Status ConfigL2TunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -669,7 +669,7 @@ absl::Status ConfigL2TunnelTableEntry(
 
 #endif  // ES2K_TARGET
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::Status ConfigFdbTxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -690,7 +690,7 @@ absl::Status ConfigFdbTxVlanTableEntry(
   return status;
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::Status ConfigFdbRxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -711,7 +711,7 @@ absl::Status ConfigFdbRxVlanTableEntry(
   return status;
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::Status ConfigFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -1356,11 +1356,11 @@ void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   }
   {
     // match remote ipv4 addr
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
+    auto match = table_entry->add_match();
+    match->set_field_id(
         GetMatchFieldId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE,
                         RX_IPV4_TUNNEL_SOURCE_PORT_TABLE_KEY_IPV4_SRC));
-    match1->mutable_exact()->set_value(
+    match->mutable_exact()->set_value(
         CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
   }
 
@@ -1397,11 +1397,11 @@ void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   }
   {
     // match remote ipv6 addr
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
+    auto match = table_entry->add_match();
+    match->set_field_id(
         GetMatchFieldId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE,
                         RX_IPV6_TUNNEL_SOURCE_PORT_TABLE_KEY_IPV6_SRC));
-    match1->mutable_exact()->set_value(
+    match->mutable_exact()->set_value(
         CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
   }
 
@@ -1429,10 +1429,10 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                  bool insert_entry) {
   {
     // match remote ipv4 addr
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
                                         IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC));
-    match1->mutable_exact()->set_value(
+    match->mutable_exact()->set_value(
         CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
   }
 
@@ -1440,20 +1440,21 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
   table_entry->set_table_id(GetTableId(p4info, IPV4_TUNNEL_TERM_TABLE));
 
   {
+    // match bridge id
     // TODO(derek): table does not have a bridge_id match field. [es2k]
     // See https://github.com/ipdk-io/networking-recipe/issues/617 for details.
     auto match = table_entry->add_match();
     match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
                                         IPV4_TUNNEL_TERM_TABLE_KEY_BRIDGE_ID));
-    match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.bridge_id));
+    match->mutable_exact()->set_value(
+        EncodeByteValue(1, tunnel_info.bridge_id));
   }
-
   {
     // match vni
-    auto match2 = table_entry->add_match();
-    match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
                                         IPV4_TUNNEL_TERM_TABLE_KEY_VNI));
-    match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
   }
 #elif defined(DPDK_TARGET)
   table_entry->set_table_id(GetTableId(p4info, IPV4_TUNNEL_TERM_TABLE));
@@ -1461,16 +1462,17 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
   {
     // match vxlan tunnel type
     auto match = table_entry->add_match();
-    match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+    match->set_field_id(
+        GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
                         IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE));
     match->mutable_exact()->set_value(EncodeByteValue(1, TUNNEL_TYPE_VXLAN));
   }
   {
     // match local ipv4 addr
-    auto match2 = table_entry->add_match();
-    match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                                         IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST));
-    match2->mutable_exact()->set_value(
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+                                        IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST));
+    match->mutable_exact()->set_value(
         CanonicalizeIp(tunnel_info.local_ip.ip.v4addr.s_addr));
   }
 #else
@@ -1558,22 +1560,23 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
     auto match = table_entry->add_match();
     match->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
                                         IPV6_TUNNEL_TERM_TABLE_KEY_BRIDGE_ID));
-    match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.bridge_id));
+    match->mutable_exact()->set_value(
+        EncodeByteValue(1, tunnel_info.bridge_id));
   }
   {
     // match remote ipv6 addr
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
                                         IPV6_TUNNEL_TERM_TABLE_KEY_IPV6_SRC));
-    match1->mutable_exact()->set_value(
+    match->mutable_exact()->set_value(
         CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
   }
   {
     // match vni
-    auto match2 = table_entry->add_match();
-    match2->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
                                         IPV6_TUNNEL_TERM_TABLE_KEY_VNI));
-    match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
   }
 
   if (insert_entry) {
@@ -1626,7 +1629,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-// called by: DoConfigTunnelEntry
+// called-by: DoConfigTunnelEntry
 absl::Status ConfigEncapTableEntry(ClientInterface& client,
                                    const struct tunnel_info& tunnel_info,
                                    const ::p4::config::v1::P4Info& p4info,
@@ -1675,8 +1678,8 @@ void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
   {
     // match vni
     auto match = table_entry->add_match();
-    match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
-                                        VXLAN_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
+    match->set_field_id(GetMatchFieldId(
+        p4info, VXLAN_DECAP_MOD_TABLE, VXLAN_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
     match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
   }
 
@@ -1698,7 +1701,8 @@ void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
   {
     // match vni
     auto match = table_entry->add_match();
-    match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
+    match->set_field_id(
+        GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
                         GENEVE_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
     match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
   }
@@ -1837,7 +1841,7 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
-// called by: DoConfigTunnelEntry
+// called-by: DoConfigTunnelEntry
 absl::Status ConfigDecapTableEntry(ClientInterface& client,
                                    const struct tunnel_info& tunnel_info,
                                    const ::p4::config::v1::P4Info& p4info,
@@ -1868,7 +1872,8 @@ void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
     auto match = table_entry->add_match();
     match->set_field_id(GetMatchFieldId(p4info, VLAN_PUSH_MOD_TABLE,
                                         VLAN_PUSH_MOD_KEY_MOD_BLOB_PTR));
-    // note: mod_blob_ptr is bit<24>, vlan_id is bit<12>, encoded value is bit<8>.
+    // note: mod_blob_ptr is bit<24>, vlan_id is bit<12>, encoded value is
+    // bit<8>.
     match->mutable_exact()->set_value(EncodeByteValue(1, vlan_id));
   }
 
@@ -1925,7 +1930,7 @@ void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-// called by: DoConfigVlanEntry
+// called-by: DoConfigVlanEntry
 absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
                                       const uint16_t vlan_id,
                                       const ::p4::config::v1::P4Info& p4info,
@@ -1940,7 +1945,7 @@ absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
   return client.sendWriteRequest(write_request);
 }
 
-// called by: DoConfigVlanEntry
+// called-by: DoConfigVlanEntry
 absl::Status ConfigVlanPopTableEntry(ClientInterface& client,
                                      const uint16_t vlan_id,
                                      const ::p4::config::v1::P4Info& p4info,
@@ -1955,7 +1960,7 @@ absl::Status ConfigVlanPopTableEntry(ClientInterface& client,
   return client.sendWriteRequest(write_request);
 }
 
-// called by: DoConfigTunnelSrcPortEntry
+// called-by: DoConfigTunnelSrcPortEntry
 void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
                               const struct src_port_info& sp,
                               const ::p4::config::v1::P4Info& p4info,
@@ -1974,14 +1979,14 @@ void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
     match->mutable_ternary()->set_mask(EncodeByteValue(2, 0xff, 0xff));
   }
   {
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
+    auto match = table_entry->add_match();
+    match->set_field_id(
         GetMatchFieldId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE,
                         SOURCE_PORT_TO_BRIDGE_MAP_TABLE_KEY_VID));
-    match1->mutable_ternary()->set_value(
+    match->mutable_ternary()->set_value(
         EncodeByteValue(2, ((sp.vlan_id >> 8) & 0x0f), (sp.vlan_id & 0xff)));
-    match1->mutable_ternary()->set_mask(EncodeByteValue(2, 0x0f, 0xff));
-    // match1->mutable_ternary()->set_mask(EncodeByteValue(1, 0xff));
+    match->mutable_ternary()->set_mask(EncodeByteValue(2, 0x0f, 0xff));
+    // match->mutable_ternary()->set_mask(EncodeByteValue(1, 0xff));
   }
 
   if (insert_entry) {
@@ -2121,8 +2126,8 @@ void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
 #if 0
   {
     /* unused match key of 0, code is added for reference */
-    auto match1 = table_entry->add_match();
-    match1->set_field_id(
+    auto match = table_entry->add_match();
+    match->set_field_id(
         GetMatchFieldId(p4info, TX_ACC_VSI_TABLE,
                         TX_ACC_VSI_TABLE_KEY_ZERO_PADDING));
     match->mutable_exact()->set_value(EncodeByteValue(1, 0));
@@ -2130,7 +2135,7 @@ void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
 #endif
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2145,7 +2150,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2160,7 +2165,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false) {
@@ -2191,7 +2196,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called by: DoConfigFdbEntry
+// called-by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false) {
@@ -2206,7 +2211,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called by: DoConfigIpMacMapEntry
+// called-by: DoConfigIpMacMapEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
     ClientInterface& client, struct ip_mac_map_info ip_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2221,7 +2226,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called by: ConfigSrcIpMacMapTableEntry
+// called-by: ConfigSrcIpMacMapTableEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2236,7 +2241,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called by: DoConfigSrcPortEntry, DoConfigFdbEntry
+// called-by: DoConfigSrcPortEntry, DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
     ClientInterface& client, uint32_t sp,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2250,7 +2255,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called by: DoConfigSrcPortEntry
+// called-by: DoConfigSrcPortEntry
 absl::Status ConfigureVsiSrcPortTableEntry(
     ClientInterface& client, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -2264,7 +2269,7 @@ absl::Status ConfigureVsiSrcPortTableEntry(
   return client.sendWriteRequest(write_request);
 }
 
-// called by: DoConfigRxTunnelSrcEntry
+// called-by: DoConfigRxTunnelSrcEntry
 absl::Status ConfigRxTunnelSrcPortTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -2286,7 +2291,7 @@ absl::Status ConfigRxTunnelSrcPortTableEntry(
 
 #endif  // ES2K_TARGET
 
-// called by: DoConfigTunnelEntry
+// called-by: DoConfigTunnelEntry
 absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
                                         const struct tunnel_info& tunnel_info,
                                         const ::p4::config::v1::P4Info& p4info,
@@ -2316,7 +2321,7 @@ absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
 
 #if defined(ES2K_TARGET)
 
-// called by: DoConfigIpMacMapEntry
+// called-by: DoConfigIpMacMapEntry
 absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
                                          const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,
@@ -2337,7 +2342,7 @@ absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
   return status;
 }
 
-// called by: DoConfigIpMacMapEntry
+// called-by: DoConfigIpMacMapEntry
 absl::Status ConfigSrcIpMacMapTableEntry(ClientInterface& client,
                                          const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -143,16 +143,21 @@ void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_L2_FWD_SMAC_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_SMAC_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_SMAC_TABLE, L2_FWD_SMAC_TABLE_KEY_SA));
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
-
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(GetMatchFieldId(p4info, L2_FWD_SMAC_TABLE,
-                                       L2_FWD_SMAC_TABLE_KEY_BRIDGE_ID));
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  {
+    // Source mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_SMAC_TABLE, L2_FWD_SMAC_TABLE_KEY_SA));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
+  {
+    // match bridge id
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(GetMatchFieldId(p4info, L2_FWD_SMAC_TABLE,
+                                         L2_FWD_SMAC_TABLE_KEY_BRIDGE_ID));
+    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -170,21 +175,25 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_L2_FWD_TX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
-
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
+  {
+    // match dest mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
+#if defined(ES2K_TARGET)
+  {
+    // match bridge id
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
+    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  }
+#endif
 
 #if defined(ES2K_TARGET)
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
-
   if (insert_entry) {
     /* Action param configured by user in TX_ACC_VSI_TABLE is used as port_id
      * We call GET api to fetch this value and pass it to FDB programming.
@@ -257,18 +266,21 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_L2_FWD_RX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_RX_TABLE, L2_FWD_RX_TABLE_KEY_DST_MAC));
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
-
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_RX_TABLE, L2_FWD_RX_TABLE_KEY_BRIDGE_ID));
-
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  {
+    // match dest mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_RX_TABLE, L2_FWD_RX_TABLE_KEY_DST_MAC));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
+  {
+    // match bridge id
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_RX_TABLE, L2_FWD_RX_TABLE_KEY_BRIDGE_ID));
+    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -295,11 +307,14 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_L2_FWD_RX_WITH_TUNNEL_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE,
-                                      L2_FWD_TX_TABLE_KEY_DST_MAC));
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
+  {
+    // match dest mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE,
+                                        L2_FWD_TX_TABLE_KEY_DST_MAC));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -330,18 +345,22 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
   detail.table_id = LOG_L2_FWD_TX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
-
+  {
+    // match dest mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
 #if defined(ES2K_TARGET)
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  {
+    // match bridge id
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
+    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  }
 #endif
 
 #if defined(DPDK_TARGET)
@@ -436,19 +455,23 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
   detail.table_id = LOG_L2_FWD_TX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
-
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
+  {
+    // match dest mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
 
 #if defined(ES2K_TARGET)
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  {
+    // match bridge id
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
+    match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  }
 #endif
 
 #if defined(DPDK_TARGET)
@@ -464,7 +487,6 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
       // note: 8-bit vni (dpdk)
       param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
     }
-
     {
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_TUNNEL,
@@ -539,11 +561,14 @@ void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_L2_TO_TUNNEL_V4_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V4_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_TO_TUNNEL_V4_TABLE, L2_TO_TUNNEL_V4_KEY_DA));
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
+  {
+    // match dest mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_TO_TUNNEL_V4_TABLE, L2_TO_TUNNEL_V4_KEY_DA));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -569,11 +594,14 @@ void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_L2_TO_TUNNEL_V6_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V6_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_TO_TUNNEL_V6_TABLE, L2_TO_TUNNEL_V6_KEY_DA));
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
+  {
+    // match dest mac addr
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_TO_TUNNEL_V6_TABLE, L2_TO_TUNNEL_V6_KEY_DA));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -592,6 +620,7 @@ void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
   }
 }
 
+// called by: DoConfigFdbEntry
 absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
                                      const struct mac_learning_info& learn_info,
                                      const ::p4::config::v1::P4Info& p4info,
@@ -613,6 +642,7 @@ absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
   return status;
 }
 
+// called by: DoConfigFdbEntry
 absl::Status ConfigL2TunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -639,6 +669,7 @@ absl::Status ConfigL2TunnelTableEntry(
 
 #endif  // ES2K_TARGET
 
+// called by: DoConfigFdbEntry
 absl::Status ConfigFdbTxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -659,6 +690,7 @@ absl::Status ConfigFdbTxVlanTableEntry(
   return status;
 }
 
+// called by: DoConfigFdbEntry
 absl::Status ConfigFdbRxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -679,6 +711,7 @@ absl::Status ConfigFdbRxVlanTableEntry(
   return status;
 }
 
+// called by: DoConfigFdbEntry
 absl::Status ConfigFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -724,11 +757,15 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
                                  const ::p4::config::v1::P4Info& p4info,
                                  bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, VXLAN_ENCAP_MOD_TABLE,
-                      VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, VXLAN_ENCAP_MOD_TABLE,
+                        VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -786,11 +823,15 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
                                   const ::p4::config::v1::P4Info& p4info,
                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, GENEVE_ENCAP_MOD_TABLE,
-                      GENEVE_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, GENEVE_ENCAP_MOD_TABLE,
+                        GENEVE_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -866,11 +907,15 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
                                    const ::p4::config::v1::P4Info& p4info,
                                    bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_V6_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, VXLAN_ENCAP_V6_MOD_TABLE,
-                      VXLAN_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, VXLAN_ENCAP_V6_MOD_TABLE,
+                        VXLAN_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -925,11 +970,14 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
                                     const ::p4::config::v1::P4Info& p4info,
                                     bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_V6_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, GENEVE_ENCAP_V6_MOD_TABLE,
-                      GENEVE_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, GENEVE_ENCAP_V6_MOD_TABLE,
+                        GENEVE_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -998,11 +1046,15 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(
-      p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE,
-      VXLAN_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(
+        p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE,
+        VXLAN_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1061,11 +1113,15 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, GENEVE_ENCAP_VLAN_POP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(
-      p4info, GENEVE_ENCAP_VLAN_POP_MOD_TABLE,
-      GENEVE_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(
+        p4info, GENEVE_ENCAP_VLAN_POP_MOD_TABLE,
+        GENEVE_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1139,11 +1195,15 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(
-      p4info, VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE,
-      VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(
+        p4info, VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE,
+        VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1202,11 +1262,15 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(
-      p4info, GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE,
-      GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(
+        p4info, GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE,
+        GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1282,18 +1346,23 @@ void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE,
-                      RX_IPV4_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
-
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE,
-                      RX_IPV4_TUNNEL_SOURCE_PORT_TABLE_KEY_IPV4_SRC));
-  match1->mutable_exact()->set_value(
-      CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE,
+                        RX_IPV4_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
+  {
+    // match remote ipv4 addr
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE,
+                        RX_IPV4_TUNNEL_SOURCE_PORT_TABLE_KEY_IPV4_SRC));
+    match1->mutable_exact()->set_value(
+        CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1318,18 +1387,23 @@ void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE,
-                      RX_IPV6_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
-
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE,
-                      RX_IPV6_TUNNEL_SOURCE_PORT_TABLE_KEY_IPV6_SRC));
-  match1->mutable_exact()->set_value(
-      CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE,
+                        RX_IPV6_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
+  {
+    // match remote ipv6 addr
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE,
+                        RX_IPV6_TUNNEL_SOURCE_PORT_TABLE_KEY_IPV6_SRC));
+    match1->mutable_exact()->set_value(
+        CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1353,43 +1427,52 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                  const struct tunnel_info& tunnel_info,
                                  const ::p4::config::v1::P4Info& p4info,
                                  bool insert_entry) {
-  // match remote ipv4 addr
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                                       IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC));
-  match1->mutable_exact()->set_value(
-      CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
+  {
+    // match remote ipv4 addr
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+                                        IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC));
+    match1->mutable_exact()->set_value(
+        CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
+  }
 
 #if defined(ES2K_TARGET)
   table_entry->set_table_id(GetTableId(p4info, IPV4_TUNNEL_TERM_TABLE));
 
-  // TODO(derek): table does not have a bridge_id match field. [es2k]
-  // See https://github.com/ipdk-io/networking-recipe/issues/617 for details.
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                                      IPV4_TUNNEL_TERM_TABLE_KEY_BRIDGE_ID));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.bridge_id));
+  {
+    // TODO(derek): table does not have a bridge_id match field. [es2k]
+    // See https://github.com/ipdk-io/networking-recipe/issues/617 for details.
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+                                        IPV4_TUNNEL_TERM_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.bridge_id));
+  }
 
-  // match vni
-  auto match2 = table_entry->add_match();
-  match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                                       IPV4_TUNNEL_TERM_TABLE_KEY_VNI));
-  match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  {
+    // match vni
+    auto match2 = table_entry->add_match();
+    match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+                                        IPV4_TUNNEL_TERM_TABLE_KEY_VNI));
+    match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 #elif defined(DPDK_TARGET)
   table_entry->set_table_id(GetTableId(p4info, IPV4_TUNNEL_TERM_TABLE));
 
-  // match vxlan tunnel type
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                                      IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE));
-  match->mutable_exact()->set_value(EncodeByteValue(1, TUNNEL_TYPE_VXLAN));
-
-  // match local ipv4 addr
-  auto match2 = table_entry->add_match();
-  match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                                       IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST));
-  match2->mutable_exact()->set_value(
-      CanonicalizeIp(tunnel_info.local_ip.ip.v4addr.s_addr));
+  {
+    // match vxlan tunnel type
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+                        IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE));
+    match->mutable_exact()->set_value(EncodeByteValue(1, TUNNEL_TYPE_VXLAN));
+  }
+  {
+    // match local ipv4 addr
+    auto match2 = table_entry->add_match();
+    match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
+                                         IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST));
+    match2->mutable_exact()->set_value(
+        CanonicalizeIp(tunnel_info.local_ip.ip.v4addr.s_addr));
+  }
 #else
 #error "ASSERT: Unknown TARGET type!"
 #endif
@@ -1468,23 +1551,30 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                    bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, IPV6_TUNNEL_TERM_TABLE));
 
-  // TODO(derek): table does not have a bridge_id match field. [es2k]
-  // See https://github.com/ipdk-io/networking-recipe/issues/617
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
-                                      IPV6_TUNNEL_TERM_TABLE_KEY_BRIDGE_ID));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.bridge_id));
-
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
-                                       IPV6_TUNNEL_TERM_TABLE_KEY_IPV6_SRC));
-  match1->mutable_exact()->set_value(
-      CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
-
-  auto match2 = table_entry->add_match();
-  match2->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
-                                       IPV6_TUNNEL_TERM_TABLE_KEY_VNI));
-  match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  {
+    // match bridge id
+    // TODO(derek): table does not have a bridge_id match field. [es2k]
+    // See https://github.com/ipdk-io/networking-recipe/issues/617
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
+                                        IPV6_TUNNEL_TERM_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.bridge_id));
+  }
+  {
+    // match remote ipv6 addr
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
+                                        IPV6_TUNNEL_TERM_TABLE_KEY_IPV6_SRC));
+    match1->mutable_exact()->set_value(
+        CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
+  }
+  {
+    // match vni
+    auto match2 = table_entry->add_match();
+    match2->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
+                                        IPV6_TUNNEL_TERM_TABLE_KEY_VNI));
+    match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1536,6 +1626,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
+// called by: DoConfigTunnelEntry
 absl::Status ConfigEncapTableEntry(ClientInterface& client,
                                    const struct tunnel_info& tunnel_info,
                                    const ::p4::config::v1::P4Info& p4info,
@@ -1580,10 +1671,14 @@ void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
                                     const ::p4::config::v1::P4Info& p4info,
                                     bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_DECAP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
-                                      VXLAN_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
+                                        VXLAN_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1599,10 +1694,14 @@ void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_DECAP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
-                                      GENEVE_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
+                        GENEVE_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1633,11 +1732,15 @@ void PrepareVxlanDecapModAndVlanPushTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE,
-                      VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE,
+                        VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1677,11 +1780,15 @@ void PrepareGeneveDecapModAndVlanPushTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE,
-                      GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+
+  {
+    // match vni
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE,
+                        GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
+    match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1730,6 +1837,7 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
+// called by: DoConfigTunnelEntry
 absl::Status ConfigDecapTableEntry(ClientInterface& client,
                                    const struct tunnel_info& tunnel_info,
                                    const ::p4::config::v1::P4Info& p4info,
@@ -1754,11 +1862,15 @@ void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
                                const ::p4::config::v1::P4Info& p4info,
                                bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_PUSH_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, VLAN_PUSH_MOD_TABLE,
-                                      VLAN_PUSH_MOD_KEY_MOD_BLOB_PTR));
-  // note: mod_blob_ptr is bit<24>, vlan_id is bit<12>, encoded value is bit<8>.
-  match->mutable_exact()->set_value(EncodeByteValue(1, vlan_id));
+
+  {
+    // match vlan id
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, VLAN_PUSH_MOD_TABLE,
+                                        VLAN_PUSH_MOD_KEY_MOD_BLOB_PTR));
+    // note: mod_blob_ptr is bit<24>, vlan_id is bit<12>, encoded value is bit<8>.
+    match->mutable_exact()->set_value(EncodeByteValue(1, vlan_id));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1795,12 +1907,16 @@ void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
                               const ::p4::config::v1::P4Info& p4info,
                               bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_POP_MOD_TABLE));
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, VLAN_POP_MOD_TABLE,
-                                      VLAN_POP_MOD_KEY_MOD_BLOB_PTR));
-  // TODO(derek): vlan_id truncated to 8 bits. [es2k]
-  // See https://github.com/ipdk-io/networking-recipe/issues/684
-  match->mutable_exact()->set_value(EncodeByteValue(1, vlan_id));
+
+  {
+    // match vlan id
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, VLAN_POP_MOD_TABLE,
+                                        VLAN_POP_MOD_KEY_MOD_BLOB_PTR));
+    // TODO(derek): vlan_id truncated to 8 bits. [es2k]
+    // See https://github.com/ipdk-io/networking-recipe/issues/684
+    match->mutable_exact()->set_value(EncodeByteValue(1, vlan_id));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1809,6 +1925,7 @@ void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
+// called by: DoConfigVlanEntry
 absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
                                       const uint16_t vlan_id,
                                       const ::p4::config::v1::P4Info& p4info,
@@ -1823,6 +1940,7 @@ absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
   return client.sendWriteRequest(write_request);
 }
 
+// called by: DoConfigVlanEntry
 absl::Status ConfigVlanPopTableEntry(ClientInterface& client,
                                      const uint16_t vlan_id,
                                      const ::p4::config::v1::P4Info& p4info,
@@ -1837,6 +1955,7 @@ absl::Status ConfigVlanPopTableEntry(ClientInterface& client,
   return client.sendWriteRequest(write_request);
 }
 
+// called by: DoConfigTunnelSrcPortEntry
 void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
                               const struct src_port_info& sp,
                               const ::p4::config::v1::P4Info& p4info,
@@ -1844,23 +1963,26 @@ void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
   table_entry->set_table_id(
       GetTableId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE));
 
-  auto match = table_entry->add_match();
-  table_entry->set_priority(1);
-  match->set_field_id(
-      GetMatchFieldId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE,
-                      SOURCE_PORT_TO_BRIDGE_MAP_TABLE_KEY_SRC_PORT));
-  match->mutable_ternary()->set_value(
-      EncodeByteValue(2, ((sp.src_port >> 8) & 0xff), (sp.src_port & 0xff)));
-  match->mutable_ternary()->set_mask(EncodeByteValue(2, 0xff, 0xff));
-
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE,
-                      SOURCE_PORT_TO_BRIDGE_MAP_TABLE_KEY_VID));
-  match1->mutable_ternary()->set_value(
-      EncodeByteValue(2, ((sp.vlan_id >> 8) & 0x0f), (sp.vlan_id & 0xff)));
-  match1->mutable_ternary()->set_mask(EncodeByteValue(2, 0x0f, 0xff));
-  // match1->mutable_ternary()->set_mask(EncodeByteValue(1, 0xff));
+  {
+    auto match = table_entry->add_match();
+    table_entry->set_priority(1);
+    match->set_field_id(
+        GetMatchFieldId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE,
+                        SOURCE_PORT_TO_BRIDGE_MAP_TABLE_KEY_SRC_PORT));
+    match->mutable_ternary()->set_value(
+        EncodeByteValue(2, ((sp.src_port >> 8) & 0xff), (sp.src_port & 0xff)));
+    match->mutable_ternary()->set_mask(EncodeByteValue(2, 0xff, 0xff));
+  }
+  {
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE,
+                        SOURCE_PORT_TO_BRIDGE_MAP_TABLE_KEY_VID));
+    match1->mutable_ternary()->set_value(
+        EncodeByteValue(2, ((sp.vlan_id >> 8) & 0x0f), (sp.vlan_id & 0xff)));
+    match1->mutable_ternary()->set_mask(EncodeByteValue(2, 0x0f, 0xff));
+    // match1->mutable_ternary()->set_mask(EncodeByteValue(1, 0xff));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1884,11 +2006,14 @@ void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_SRC_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, SRC_IP_MAC_MAP_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, SRC_IP_MAC_MAP_TABLE,
-                                      SRC_IP_MAC_MAP_TABLE_KEY_SRC_IP));
-  match->mutable_exact()->set_value(
-      CanonicalizeIp(ip_info.src_ip_addr.ip.v4addr.s_addr));
+  {
+    // match ipv4 addr
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, SRC_IP_MAC_MAP_TABLE,
+                                        SRC_IP_MAC_MAP_TABLE_KEY_SRC_IP));
+    match->mutable_exact()->set_value(
+        CanonicalizeIp(ip_info.src_ip_addr.ip.v4addr.s_addr));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1933,11 +2058,14 @@ void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   detail.table_id = LOG_DST_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, DST_IP_MAC_MAP_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, DST_IP_MAC_MAP_TABLE,
-                                      DST_IP_MAC_MAP_TABLE_KEY_DST_IP));
-  match->mutable_exact()->set_value(
-      CanonicalizeIp((ip_info.dst_ip_addr.ip.v4addr.s_addr)));
+  {
+    // match dst ipv4 addr
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, DST_IP_MAC_MAP_TABLE,
+                                        DST_IP_MAC_MAP_TABLE_KEY_DST_IP));
+    match->mutable_exact()->set_value(
+        CanonicalizeIp((ip_info.dst_ip_addr.ip.v4addr.s_addr)));
+  }
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1979,24 +2107,30 @@ void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
                                const ::p4::config::v1::P4Info& p4info) {
   table_entry->set_table_id(GetTableId(p4info, TX_ACC_VSI_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, TX_ACC_VSI_TABLE, TX_ACC_VSI_TABLE_KEY_VSI));
-  // TODO(derek): sp value truncated to 8 bits. [es2k]
-  // See https://github.com/ipdk-io/networking-recipe/issues/680 for details.
-  match->mutable_exact()->set_value(
-      EncodeByteValue(1, (sp - ES2K_VPORT_ID_OFFSET)));
+  {
+    // match vsi
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, TX_ACC_VSI_TABLE, TX_ACC_VSI_TABLE_KEY_VSI));
+    // TODO(derek): sp value truncated to 8 bits. [es2k]
+    // See https://github.com/ipdk-io/networking-recipe/issues/680 for details.
+    match->mutable_exact()->set_value(
+        EncodeByteValue(1, (sp - ES2K_VPORT_ID_OFFSET)));
+  }
 
 #if 0
-  /* unused match key of 0, code is added for reference */
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, TX_ACC_VSI_TABLE,
-                      TX_ACC_VSI_TABLE_KEY_ZERO_PADDING));
-  match->mutable_exact()->set_value(EncodeByteValue(1, 0));
+  {
+    /* unused match key of 0, code is added for reference */
+    auto match1 = table_entry->add_match();
+    match1->set_field_id(
+        GetMatchFieldId(p4info, TX_ACC_VSI_TABLE,
+                        TX_ACC_VSI_TABLE_KEY_ZERO_PADDING));
+    match->mutable_exact()->set_value(EncodeByteValue(1, 0));
+  }
 #endif
 }
 
+// called by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2011,6 +2145,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
   return client.sendReadRequest(read_request);
 }
 
+// called by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2025,6 +2160,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
   return client.sendReadRequest(read_request);
 }
 
+// called by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false) {
@@ -2055,6 +2191,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
   return client.sendReadRequest(read_request);
 }
 
+// called by: DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false) {
@@ -2069,6 +2206,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
   return client.sendReadRequest(read_request);
 }
 
+// called by: DoConfigIpMacMapEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
     ClientInterface& client, struct ip_mac_map_info ip_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2083,6 +2221,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
   return client.sendReadRequest(read_request);
 }
 
+// called by: ConfigSrcIpMacMapTableEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2097,6 +2236,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
   return client.sendReadRequest(read_request);
 }
 
+// called by: DoConfigSrcPortEntry, DoConfigFdbEntry
 absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
     ClientInterface& client, uint32_t sp,
     const ::p4::config::v1::P4Info& p4info) {
@@ -2110,6 +2250,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
   return client.sendReadRequest(read_request);
 }
 
+// called by: DoConfigSrcPortEntry
 absl::Status ConfigureVsiSrcPortTableEntry(
     ClientInterface& client, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -2123,6 +2264,7 @@ absl::Status ConfigureVsiSrcPortTableEntry(
   return client.sendWriteRequest(write_request);
 }
 
+// called by: DoConfigRxTunnelSrcEntry
 absl::Status ConfigRxTunnelSrcPortTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -2144,6 +2286,7 @@ absl::Status ConfigRxTunnelSrcPortTableEntry(
 
 #endif  // ES2K_TARGET
 
+// called by: DoConfigTunnelEntry
 absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
                                         const struct tunnel_info& tunnel_info,
                                         const ::p4::config::v1::P4Info& p4info,
@@ -2173,6 +2316,7 @@ absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
 
 #if defined(ES2K_TARGET)
 
+// called by: DoConfigIpMacMapEntry
 absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
                                          const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,
@@ -2193,6 +2337,7 @@ absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
   return status;
 }
 
+// called by: DoConfigIpMacMapEntry
 absl::Status ConfigSrcIpMacMapTableEntry(ClientInterface& client,
                                          const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,


### PR DESCRIPTION
- Ensured that each code sequence that defines a match key is
  enclosed in a block.

- Renamed `match1` and `match2` variables to `match`. They
  are now local to the match-key block, and do not need unique
  names.

- Added a brief one-line comment to each block, specifying the
  key that is being defined.

- Added a `called-by:` comment to each ConfigTableEntry function,
  documenting the DoConfigTableEntry function that calls it.