### PR TITLE
[ovsp4rt] Implement dpdk_config_fdb_entry_test

### DIFF
--- a/ovs-p4rt/sidecar/client/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/client/CMakeLists.txt
@@ -10,6 +10,8 @@
 add_library(ovsp4rt_client_o OBJECT
   ovsp4rt_client.cc
   ovsp4rt_client.h
+  ovsp4rt_client_flags.cc
+  ovsp4rt_client_flags.h
   ovsp4rt_client_interface.h
 )
 
@@ -49,4 +51,33 @@ add_library(ovsp4rt_client_so SHARED EXCLUDE_FROM_ALL
 
 set_target_properties(ovsp4rt_client_so PROPERTIES
   OUTPUT_NAME ovsp4rt_client
+)
+
+#-----------------------------------------------------------------------
+# ovsp4rt_test_client_o
+#-----------------------------------------------------------------------
+add_library(ovsp4rt_test_client_o OBJECT
+  ovsp4rt_client_flags.h
+  ovsp4rt_client_interface.h
+  ovsp4rt_test_client.cc
+  ovsp4rt_test_client.h
+)
+
+target_include_directories(ovsp4rt_test_client_o PUBLIC
+  ${OVSP4RT_INCLUDE_DIR}
+  ${SIDECAR_SOURCE_DIR}
+  ${STRATUM_SOURCE_DIR}
+)
+
+target_link_libraries(ovsp4rt_test_client_o PUBLIC
+  p4_role_config_proto
+  p4runtime_proto
+  stratum_utils
+)
+
+#-----------------------------------------------------------------------
+# libovsp4rt_test_client.a
+#-----------------------------------------------------------------------
+add_library(ovsp4rt_test_client STATIC
+  $<TARGET_OBJECTS:ovsp4rt_test_client_o>
 )

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client.cc
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client.cc
@@ -6,14 +6,9 @@
 #include "absl/flags/flag.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "ovsp4rt_client_flags.h"
 #include "session/ovsp4rt_credentials.h"
 #include "session/ovsp4rt_session.h"
-
-#define DEFAULT_ROLE_NAME "ovs-p4rt"
-
-ABSL_FLAG(uint64_t, device_id, 1, "P4Runtime device ID.");
-
-ABSL_FLAG(std::string, role_name, DEFAULT_ROLE_NAME, "P4 config role name.");
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client_flags.cc
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client_flags.cc
@@ -1,0 +1,13 @@
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_client_flags.h"
+
+#include <absl/flags/flag.h>
+
+#define DEFAULT_ROLE_NAME "ovs-p4rt"
+
+ABSL_FLAG(uint64_t, device_id, 1, "P4Runtime device ID.");
+
+ABSL_FLAG(std::string, role_name, DEFAULT_ROLE_NAME, "P4 config role name.");

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client_flags.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client_flags.h
@@ -1,0 +1,15 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_CLIENT_FLAGS_H
+#define OVSP4RT_CLIENT_FLAGS_H
+
+#include <absl/flags/declare.h>
+#include <stdint.h>
+
+#include <string>
+
+ABSL_DECLARE_FLAG(uint64_t, device_id);
+ABSL_DECLARE_FLAG(std::string, role_name);
+
+#endif  // OVSP4RT_CLIENT_FLAGS_H

--- a/ovs-p4rt/sidecar/client/ovsp4rt_test_client.cc
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_test_client.cc
@@ -1,0 +1,53 @@
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_test_client.h"
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "ovsp4rt_client.h"
+#include "ovsp4rt_client_flags.h"
+
+namespace ovsp4rt {
+
+TestClient::TestClient()
+    : device_id_(absl::GetFlag(FLAGS_device_id)),
+      role_name_(absl::GetFlag(FLAGS_role_name)) {}
+
+absl::Status TestClient::connect(const char* grpc_addr) {
+  return absl::OkStatus();
+}
+
+absl::Status TestClient::getPipelineConfig(::p4::config::v1::P4Info* p4info) {
+  return absl::UnimplementedError("getPipelineConfig");
+}
+
+::p4::v1::TableEntry* TestClient::initReadRequest(
+    ::p4::v1::ReadRequest* request) {
+  request->set_device_id(device_id_);
+  auto* entity = request->add_entities();
+  return entity->mutable_table_entry();
+}
+
+absl::StatusOr<::p4::v1::ReadResponse> TestClient::DoSendReadRequest(
+    const p4::v1::ReadRequest& request) {
+  return absl::UnimplementedError("DoSendReadRequest");
+}
+
+absl::Status TestClient::DoSendWriteRequest(
+    const p4::v1::WriteRequest& request) {
+  return absl::UnimplementedError("DoSendWriteRequest");
+}
+
+::p4::v1::TableEntry* TestClient::InitWriteRequest(
+    ::p4::v1::WriteRequest* request, ::p4::v1::Update_Type type_value) {
+  request->set_device_id(device_id_);
+  *request->mutable_election_id() = election_id_;
+  auto* update = request->add_updates();
+  update->set_type(type_value);
+  return update->mutable_entity()->mutable_table_entry();
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/client/ovsp4rt_test_client.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_test_client.h
@@ -1,0 +1,101 @@
+// Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_TEST_CLIENT_H_
+#define OVSP4RT_TEST_CLIENT_H_
+
+#include <stdint.h>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "ovsp4rt_client_interface.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "session/ovsp4rt_session.h"
+
+namespace ovsp4rt {
+
+class TestClient : public ClientInterface {
+ public:
+  TestClient();
+  virtual ~TestClient() = default;
+
+  // Connects to the P4Runtime server.
+  virtual absl::Status connect(const char* grpc_addr) override;
+
+  // Gets the pipeline configuration from the P4Runtime server.
+  virtual absl::Status getPipelineConfig(
+      ::p4::config::v1::P4Info* p4info) override;
+
+  //--------------------------------------------------------------------
+
+  // Initializes a Read Table Entry request message.
+  virtual ::p4::v1::TableEntry* initReadRequest(
+      ::p4::v1::ReadRequest* request) override;
+
+  // Sends a Read Table Entry request to the P4Runtime server.
+  virtual absl::StatusOr<p4::v1::ReadResponse> sendReadRequest(
+      const p4::v1::ReadRequest& request) override {
+    return DoSendReadRequest(request);
+  }
+
+  //--------------------------------------------------------------------
+
+  // Initializes an Insert Table Entry request message.
+  virtual ::p4::v1::TableEntry* initInsertRequest(
+      ::p4::v1::WriteRequest* request) override {
+    return InitWriteRequest(request, ::p4::v1::Update::INSERT);
+  }
+
+  // Initializes a Modify Table Entry request message.
+  virtual ::p4::v1::TableEntry* initModifyRequest(
+      ::p4::v1::WriteRequest* request) override {
+    return InitWriteRequest(request, ::p4::v1::Update::MODIFY);
+  }
+
+  // Initializes a Delete Table Entry request message.
+  virtual ::p4::v1::TableEntry* initDeleteRequest(
+      ::p4::v1::WriteRequest* request) override {
+    return InitWriteRequest(request, ::p4::v1::Update::DELETE);
+  }
+
+  // Initializes an Insert Table Entry or Delete Table Entry request
+  // message, depending on the value of the `insert_entry` parameter.
+  virtual ::p4::v1::TableEntry* initWriteRequest(
+      ::p4::v1::WriteRequest* request, bool insert_entry) override {
+    if (insert_entry) {
+      return initInsertRequest(request);
+    } else {
+      return initDeleteRequest(request);
+    }
+  }
+
+  // Sends a Write Table Entry request to the P4Runtime server.
+  virtual absl::Status sendWriteRequest(
+      const p4::v1::WriteRequest& request) override {
+    return DoSendWriteRequest(request);
+  }
+
+  //--------------------------------------------------------------------
+
+ protected:
+  // Implements sendReadRequest().
+  absl::StatusOr<p4::v1::ReadResponse> DoSendReadRequest(
+      const p4::v1::ReadRequest& request);
+
+  // Implements sendWriteRequest();
+  absl::Status DoSendWriteRequest(const p4::v1::WriteRequest& request);
+
+  // Initializes a WriteRequest message.
+  ::p4::v1::TableEntry* InitWriteRequest(::p4::v1::WriteRequest* request,
+                                         ::p4::v1::Update_Type type_value);
+
+ private:
+  uint64_t device_id_;
+  p4::v1::Uint128 election_id_;
+  std::string role_name_;
+};
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_TEST_CLIENT_H_

--- a/ovs-p4rt/sidecar/client/ovsp4rt_test_client_mock.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_test_client_mock.h
@@ -1,0 +1,44 @@
+// Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_TEST_CLIENT_MOCK_H_
+#define OVSP4RT_TEST_CLIENT_MOCK_H_
+
+#include "gmock/gmock.h"
+#include "ovsp4rt_test_client.h"
+
+namespace ovsp4rt {
+
+class TestClientMock : public TestClient {
+ public:
+  MOCK_METHOD(absl::Status, connect, (const char*));
+
+  MOCK_METHOD(absl::Status, getPipelineConfig, (::p4::config::v1::P4Info*));
+
+  MOCK_METHOD(::p4::v1::TableEntry*, initReadRequest, (::p4::v1::ReadRequest*));
+
+  MOCK_METHOD(absl::StatusOr<p4::v1::ReadResponse>, sendReadRequest,
+              (const p4::v1::ReadRequest&));
+
+#if false
+  MOCK_METHOD(::p4::v1::TableEntry*, initInsertRequest,
+              (::p4::v1::WriteRequest*));
+
+  MOCK_METHOD(::p4::v1::TableEntry*, initModifyRequest,
+              (::p4::v1::WriteRequest*));
+
+  MOCK_METHOD(::p4::v1::TableEntry*, initDeleteRequest,
+              (::p4::v1::WriteRequest*));
+
+  MOCK_METHOD(::p4::v1::TableEntry*, initWriteRequest,
+              (::p4::v1::WriteRequest*, bool));
+#endif
+
+  MOCK_METHOD(absl::Status, sendWriteRequest,
+              (const p4::v1::WriteRequest& request));
+};
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_TEST_CLIENT_MOCK_H_

--- a/ovs-p4rt/sidecar/tests/dpdk/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/dpdk/CMakeLists.txt
@@ -44,9 +44,8 @@ macro(define_dpdk_test TARGET)
 endmacro(define_dpdk_test)
 
 #-----------------------------------------------------------------------
-# DPDK unit tests
+# DPDK PrepareTableEntry unit tests
 #-----------------------------------------------------------------------
-# PrepareTableEntry tests
 define_dpdk_test(dpdk_fdb_rx_vlan_test)
 define_dpdk_test(dpdk_fdb_tx_vlan_test)
 define_dpdk_test(dpdk_fdb_tx_vxlan_test)
@@ -55,9 +54,32 @@ define_dpdk_test(dpdk_tunnel_term_test)
 
 define_dpdk_test(dpdk_vxlan_encap_test)
 
+#-----------------------------------------------------------------------
+# define_dpdk_config_test()
+#-----------------------------------------------------------------------
+macro(define_dpdk_config_test TARGET)
+  add_executable(${TARGET}
+    ${TARGET}.cc
+    test_main.cc
+    $<TARGET_OBJECTS:ovsp4rt_test_client_o>
+  )
+
+  set_test_properties(${TARGET})
+
+  target_link_libraries(${TARGET} PUBLIC
+    absl::flags_parse
+    p4runtime_proto
+    stratum_utils
+  )
+
+  list(APPEND UNIT_TEST_NAMES ${TARGET})
+endmacro(define_dpdk_config_test)
+
+#-----------------------------------------------------------------------
+# DPDK ConfigTableEntry unit tests
+#-----------------------------------------------------------------------
 if(BUILD_CLIENT)
-  # ConfigTableEntry tests
-  define_dpdk_test(dpdk_config_fdb_entry_test)
+  define_dpdk_config_test(dpdk_config_fdb_entry_test)
 endif()
 
 # Export list of unit tests.

--- a/ovs-p4rt/sidecar/tests/dpdk/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/dpdk/CMakeLists.txt
@@ -1,6 +1,7 @@
-# CMake build file for ovs-p4rt/sidecar/tests/es2k
+# CMake build file for ovs-p4rt/sidecar/tests/dpdk
 #
 # Copyright 2024 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -45,6 +46,7 @@ endmacro(define_dpdk_test)
 #-----------------------------------------------------------------------
 # DPDK unit tests
 #-----------------------------------------------------------------------
+# PrepareTableEntry tests
 define_dpdk_test(dpdk_fdb_rx_vlan_test)
 define_dpdk_test(dpdk_fdb_tx_vlan_test)
 define_dpdk_test(dpdk_fdb_tx_vxlan_test)
@@ -52,6 +54,11 @@ define_dpdk_test(dpdk_fdb_tx_vxlan_test)
 define_dpdk_test(dpdk_tunnel_term_test)
 
 define_dpdk_test(dpdk_vxlan_encap_test)
+
+if(BUILD_CLIENT)
+  # ConfigTableEntry tests
+  define_dpdk_test(dpdk_config_fdb_entry_test)
+endif()
 
 # Export list of unit tests.
 set(UNIT_TEST_NAMES "${UNIT_TEST_NAMES}" PARENT_SCOPE)

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_fdb_entry_test.cc
@@ -7,7 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "client/ovsp4rt_client_mock.h"
+#include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_doconfig_int.h"
 #include "p4/config/v1/p4info.pb.h"
@@ -32,17 +32,19 @@ class DpdkConfigFdbEntryTest : public ::testing::Test {
 };
 
 TEST_F(DpdkConfigFdbEntryTest, connectFailure) {
-  ClientMock client;
+  TestClientMock client;
 
   EXPECT_CALL(client, connect).WillOnce(Return(absl::InternalError("connect")));
 
   auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 
   ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "connect")
+      << status.message();
 }
 
 TEST_F(DpdkConfigFdbEntryTest, getPipelineConfigFailure) {
-  ClientMock client;
+  TestClientMock client;
 
   EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
   EXPECT_CALL(client, getPipelineConfig)
@@ -51,12 +53,12 @@ TEST_F(DpdkConfigFdbEntryTest, getPipelineConfigFailure) {
   auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 
   ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "getPipelineConfig")
+      << status.message();
 }
 
-#if false
-
-TEST_F(DpdkConfigFdbEntryTest, configTunnelEntryFailure) {
-  ClientMock client;
+TEST_F(DpdkConfigFdbEntryTest, configTunnelEntryWriteFailure) {
+  TestClientMock client_mock;
   ::p4::config::v1::P4Info expected_p4info;
 
   {
@@ -66,52 +68,59 @@ TEST_F(DpdkConfigFdbEntryTest, configTunnelEntryFailure) {
         << "Error parsing P4INFO_TEXT: " << status.error_message();
   }
 
-  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
-  EXPECT_CALL(client, getPipelineConfig)
+  // TODO(derek): initialize learn_info_
+
+  EXPECT_CALL(client_mock, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client_mock, getPipelineConfig)
       .WillOnce(
           DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
-  EXPECT_CALL(client, sendWriteRequest)
+  EXPECT_CALL(client_mock, sendWriteRequest)
       .WillOnce(Return(absl::InternalError("sendWriteRequest")));
 
-  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+  auto status =
+      DoConfigFdbEntry(client_mock, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 
   ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "sendWriteRequest")
+      << status.message();
 }
 
-TEST_F(DpdkConfigFdbEntryTest, configTunnelEntrySuccess) {
-  ClientMock client;
+#if false
+
+TEST_F(DpdkConfigFdbEntryTest, configTunnelEntryWriteSuccess) {
+  TestClientMock client;
 
   EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
 
   auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 }
 
-TEST_F(DpdkConfigFdbEntryTest, configVlanTxEntryFailure) {
-  ClientMock client;
+TEST_F(DpdkConfigFdbEntryTest, configVlanTxEntryWriteFailure) {
+  TestClientMock client;
 
   EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
 
   auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 }
 
-TEST_F(DpdkConfigFdbEntryTest, configVlanTxEntrySuccess) {
-  ClientMock client;
+TEST_F(DpdkConfigFdbEntryTest, configVlanTxEntryWriteSuccess) {
+  TestClientMock client;
 
   EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
 
   auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 }
 
-TEST_F(DpdkConfigFdbEntryTest, configVlanRxEntryFailure) {
-  ClientMock client;
+TEST_F(DpdkConfigFdbEntryTest, configVlanRxEntryWriteFailure) {
+  TestClientMock client;
 
   EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
 
   auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 }
 
-TEST_F(DpdkConfigFdbEntryTest, configVlanRxEntrySuccess) {
-  ClientMock client;
+TEST_F(DpdkConfigFdbEntryTest, configVlanRxEntryWriteSuccess) {
+  TestClientMock client;
   auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
 }
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_fdb_entry_test.cc
@@ -1,0 +1,120 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for DPDK version of DoConfigFdbEntry().
+
+#include <absl/status/status.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "client/ovsp4rt_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
+
+class DpdkConfigFdbEntryTest : public ::testing::Test {
+ protected:
+  DpdkConfigFdbEntryTest() {}
+  ~DpdkConfigFdbEntryTest() = default;
+
+  struct mac_learning_info learn_info_;
+};
+
+TEST_F(DpdkConfigFdbEntryTest, connectFailure) {
+  ClientMock client;
+
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::InternalError("connect")));
+
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+}
+
+TEST_F(DpdkConfigFdbEntryTest, getPipelineConfigFailure) {
+  ClientMock client;
+
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError("getPipelineConfig")));
+
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+}
+
+#if false
+
+TEST_F(DpdkConfigFdbEntryTest, configTunnelEntryFailure) {
+  ClientMock client;
+  ::p4::config::v1::P4Info expected_p4info;
+
+  {
+    // Note: return value is stratum::Status, not absl::Status.
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, &expected_p4info);
+    ASSERT_TRUE(status.ok())
+        << "Error parsing P4INFO_TEXT: " << status.error_message();
+  }
+
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(
+          DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
+  EXPECT_CALL(client, sendWriteRequest)
+      .WillOnce(Return(absl::InternalError("sendWriteRequest")));
+
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+}
+
+TEST_F(DpdkConfigFdbEntryTest, configTunnelEntrySuccess) {
+  ClientMock client;
+
+  EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
+
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+}
+
+TEST_F(DpdkConfigFdbEntryTest, configVlanTxEntryFailure) {
+  ClientMock client;
+
+  EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
+
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+}
+
+TEST_F(DpdkConfigFdbEntryTest, configVlanTxEntrySuccess) {
+  ClientMock client;
+
+  EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
+
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+}
+
+TEST_F(DpdkConfigFdbEntryTest, configVlanRxEntryFailure) {
+  ClientMock client;
+
+  EXPECT_CALL(client, connect).WillByDefault(Return(absl::OkStatus()));
+
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+}
+
+TEST_F(DpdkConfigFdbEntryTest, configVlanRxEntrySuccess) {
+  ClientMock client;
+  auto status = DoConfigFdbEntry(client, learn_info_, INSERT_ENTRY, GRPC_ADDR);
+}
+
+#endif  // false
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/set_test_properties.cmake
+++ b/ovs-p4rt/sidecar/tests/set_test_properties.cmake
@@ -1,5 +1,6 @@
 #
 # Copyright 2024 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -17,6 +18,7 @@ function(set_test_properties TARGET)
 
   target_link_libraries(${TARGET} PUBLIC
     GTest::gtest
+    GTest::gmock
     ovsp4rt_test
     p4runtime_proto
     stratum_utils


### PR DESCRIPTION
- Implemented `dpdk_config_fdb_entry_test` and the first three test cases. It is the first test for one of the new DoConfigTableEntry functions (`DoConfigFdbTableEntry`).
- Implemented `TestClient` and `TestClientMock` classes.
- Moved the definitions of the Client command-line flags to `ovsp4rt_client_flags.cc` and `ovsp4rt_client_flags.h`.