### PR TITLE
[ovsp4rt] Fix problems with dpdk test coverage

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -126,6 +126,8 @@ if(TEST_COVERAGE)
 #-----------------------------------------------------------------------
 add_library(ovsp4rt_static STATIC
     $<TARGET_OBJECTS:ovs_sidecar_o>
+    ${OVSP4RT_CLIENT_OBJECTS}
+    ${OVSP4RT_JOURNAL_OBJECTS}
     $<TARGET_OBJECTS:ovsp4rt_logging_o>
     $<TARGET_OBJECTS:ovsp4rt_session_o>
 )

--- a/scripts/dpdk/report-ovsp4rt-coverage.sh
+++ b/scripts/dpdk/report-ovsp4rt-coverage.sh
@@ -39,6 +39,7 @@ lcov --capture \
      --directory ${INPUT_DIR} \
      --output-file ${OUTPUT_DIR}/coverage.info \
      --exclude '/opt/deps/*' \
+     --exclude '/opt/p4dev/*' \
      --exclude '/usr/include/*'
 
 # Generate html coverage report.


### PR DESCRIPTION
- Fixed link errors when building with test coverage enabled.

- Added an --exclude prefix to `report-ovsp4rt-coverage.sh`.