### PR TITLE
Implemented BaseMacLearnInfoTest

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -68,6 +68,11 @@ extern void Es2kPrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
                                        const ::p4::config::v1::P4Info& p4info,
                                        bool insert_entry);
 
+extern void Es2kPrepareFdbTunnelTableEntry(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
+    DiagDetail& detail);
+
 extern void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
                                          const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,
@@ -77,11 +82,6 @@ extern void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
                                      const struct mac_learning_info& learn_info,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry, DiagDetail& detail);
-
-extern void Es2kPrepareFdbTunnelTableEntry(
-    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
-    DiagDetail& detail);
 
 extern void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
                                          const struct ip_mac_map_info& ip_info,

--- a/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
@@ -168,10 +168,13 @@ endmacro()
 define_es2k_mac_map_test(es2k_config_dst_ip_mac_map_test)
 define_es2k_mac_map_test(es2k_config_src_ip_mac_map_test)
 
-define_es2k_config_test(es2k_prep_fdb_tunnel_table_test)
-
 define_es2k_config_test(es2k_update_src_port_test)
 define_es2k_config_test(es2k_update_tunnel_info_test)
+
+#-----------------------------------------------------------------------
+# es2k_mac_learn_info_tests
+#-----------------------------------------------------------------------
+include(es2k_mac_learn_info_tests.cmake)
 
 if(BUILD_CLIENT AND EXTRA_TESTS)
   add_subdirectory(extra)

--- a/ovs-p4rt/sidecar/tests/es2k/base_mac_learn_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/base_mac_learn_info_test.cc
@@ -1,0 +1,55 @@
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#include "base_mac_learn_info_test.h"
+
+#include <absl/status/status.h>
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+
+#include "ovsp4rt/ovs-p4rt.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+namespace ovsp4rt {
+
+void BaseMacLearnInfoTest::InitV4NativeTagged(
+    struct mac_learning_info& fdb_info) {
+  fdb_info.tnl_info.local_ip.family = AF_INET;
+  fdb_info.tnl_info.remote_ip.family = AF_INET;
+  fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
+  fdb_info.tnl_info.vni = 0x1984U;
+}
+
+void BaseMacLearnInfoTest::InitV4NativeUntagged(
+    struct mac_learning_info& fdb_info) {
+  fdb_info.tnl_info.local_ip.family = AF_INET;
+  fdb_info.tnl_info.remote_ip.family = AF_INET;
+  fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
+  fdb_info.tnl_info.vni = 0x1776U;
+}
+
+void BaseMacLearnInfoTest::InitV6NativeTagged(
+    struct mac_learning_info& fdb_info) {
+  fdb_info.tnl_info.local_ip.family = AF_INET6;
+  fdb_info.tnl_info.remote_ip.family = AF_INET6;
+  fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
+  fdb_info.tnl_info.vni = 0xFACEU;
+}
+
+void BaseMacLearnInfoTest::InitV6NativeUntagged(
+    struct mac_learning_info& fdb_info) {
+  fdb_info.tnl_info.local_ip.family = AF_INET6;
+  fdb_info.tnl_info.remote_ip.family = AF_INET6;
+  fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
+  fdb_info.tnl_info.vni = 0xCEDEU;
+}
+
+void BaseMacLearnInfoTest::InitP4Info(::p4::config::v1::P4Info* p4info) {
+  auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+  EXPECT_TRUE(status.ok()) << "ParseProtoFromString: "
+                           << status.error_message();
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/base_mac_learn_info_test.h
+++ b/ovs-p4rt/sidecar/tests/es2k/base_mac_learn_info_test.h
@@ -1,0 +1,32 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BASE_MAC_LEARN_INFO_TEST_H_
+#define BASE_MAC_LEARN_INFO_TEST_H_
+
+#include <gtest/gtest.h>
+
+#include "ovsp4rt/ovs-p4rt.h"
+#include "p4/config/v1/p4info.pb.h"
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+class BaseMacLearnInfoTest : public ::testing::Test {
+ protected:
+  BaseMacLearnInfoTest() {}
+  virtual ~BaseMacLearnInfoTest() = default;
+
+  static void InitV4NativeTagged(struct mac_learning_info& fdb_info);
+  static void InitV4NativeUntagged(struct mac_learning_info& fdb_info);
+  static void InitV6NativeTagged(struct mac_learning_info& fdb_info);
+  static void InitV6NativeUntagged(struct mac_learning_info& fdb_info);
+
+  static void InitP4Info(::p4::config::v1::P4Info* p4info);
+};
+
+}  // namespace ovsp4rt
+
+#endif  // BASE_MAC_LEARN_INFO_TEST_H_

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_mac_learn_info_tests.cmake
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_mac_learn_info_tests.cmake
@@ -1,0 +1,47 @@
+# es2k_mac_learn_info_tests.cmake
+#
+# Copyright 2025 Derek Foster
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#-----------------------------------------------------------------------
+# es2k_mac_learn_info
+#-----------------------------------------------------------------------
+add_library(es2k_mac_learn_info STATIC
+  base_mac_learn_info_test.cc
+  base_mac_learn_info_test.h
+  p4info_text.h
+  test_main.cc
+)
+
+target_include_directories(es2k_mac_learn_info PUBLIC
+  ${SIDECAR_SOURCE_DIR}
+  ${STRATUM_SOURCE_DIR}
+  ${OVSP4RT_INCLUDE_DIR}
+)
+
+target_link_libraries(es2k_mac_learn_info PUBLIC
+  absl::flags_parse
+  p4runtime_proto
+  stratum_utils
+)
+
+#-----------------------------------------------------------------------
+# define_es2k_mac_learn_test()
+#-----------------------------------------------------------------------
+macro(define_es2k_mac_learn_test TARGET)
+  add_executable(${TARGET}
+    ${TARGET}.cc
+    $<TARGET_OBJECTS:ovsp4rt_test_client_o>
+  )
+
+  set_test_properties(${TARGET})
+
+  target_link_libraries(${TARGET} PUBLIC
+    es2k_mac_learn_info
+  )
+
+  list(APPEND UNIT_TEST_NAMES ${TARGET})
+endmacro()
+
+define_es2k_mac_learn_test(es2k_prep_fdb_tunnel_table_test)

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_prep_fdb_tunnel_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_prep_fdb_tunnel_table_test.cc
@@ -4,30 +4,20 @@
 // Unit test for Es2kPrepareFdbTunnelTableEntry().
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "client/ovsp4rt_test_client_mock.h"
+#include "base_mac_learn_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
 #include "p4/config/v1/p4info.pb.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
-
-using ::testing::InvokeWithoutArgs;
-using ::testing::Return;
 
 namespace ovsp4rt {
 
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-constexpr bool DELETE_ENTRY = false;
 constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
 
-class Es2kPrepFdbTunnelTableTest : public ::testing::Test {
+class Es2kPrepFdbTunnelTableTest : public BaseMacLearnInfoTest {
  protected:
   Es2kPrepFdbTunnelTableTest() {}
   virtual ~Es2kPrepFdbTunnelTableTest() = default;
@@ -41,51 +31,6 @@ class Es2kPrepFdbTunnelTableTest : public ::testing::Test {
     fdb_info.bridge_id = BRIDGE_ID;
     fdb_info.tnl_info.tunnel_type = tunnel_type;
     fdb_info.is_tunnel = true;
-  }
-
-  static void InitVlanLearnInfo(struct mac_learning_info& fdb_info) {
-    constexpr uint8_t MAC_ADDR[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
-    constexpr uint8_t BRIDGE_ID = 99;
-    constexpr uint32_t SRC_PORT = 0x42;
-
-    memcpy(fdb_info.mac_addr, MAC_ADDR, sizeof(fdb_info.mac_addr));
-    fdb_info.bridge_id = BRIDGE_ID;
-    fdb_info.rx_src_port = SRC_PORT;
-    fdb_info.is_vlan = true;
-  }
-
-  static void InitV4NativeTagged(struct mac_learning_info& fdb_info) {
-    fdb_info.tnl_info.local_ip.family = AF_INET;
-    fdb_info.tnl_info.remote_ip.family = AF_INET;
-    fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
-    fdb_info.tnl_info.vni = 0x1984U;
-  }
-
-  static void InitV4NativeUntagged(struct mac_learning_info& fdb_info) {
-    fdb_info.tnl_info.local_ip.family = AF_INET;
-    fdb_info.tnl_info.remote_ip.family = AF_INET;
-    fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
-    fdb_info.tnl_info.vni = 0x1776U;
-  }
-
-  static void InitV6NativeTagged(struct mac_learning_info& fdb_info) {
-    fdb_info.tnl_info.local_ip.family = AF_INET6;
-    fdb_info.tnl_info.remote_ip.family = AF_INET6;
-    fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
-    fdb_info.tnl_info.vni = 0xFACEU;
-  }
-
-  static void InitV6NativeUntagged(struct mac_learning_info& fdb_info) {
-    fdb_info.tnl_info.local_ip.family = AF_INET6;
-    fdb_info.tnl_info.remote_ip.family = AF_INET6;
-    fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
-    fdb_info.tnl_info.vni = 0xCEDEU;
-  }
-
-  static void InitP4Info(::p4::config::v1::P4Info* p4info) {
-    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status.error_message();
   }
 
   static void CheckActionId(const ::p4::v1::TableEntry& table_entry,


### PR DESCRIPTION
- Defined a base class for unit tests that operate on the `mac_learning_info` struct. Modified `Es2kPrepFdbTunnelTableTest` to use it.`