### PR TITLE
Implement ovsp4rt_util_int.h

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -15,6 +15,7 @@
 #include "ovsp4rt_config_int.h"
 #include "ovsp4rt_doconfig_int.h"
 #include "ovsp4rt_private.h"
+#include "ovsp4rt_util_int.h"
 
 #if defined(DPDK_TARGET)
 #include "dpdk/p4_name_mapping.h"

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -5,27 +5,12 @@
 #ifndef OVSP4RT_PRIVATE_H_
 #define OVSP4RT_PRIVATE_H_
 
-#include <stdarg.h>
-#include <stdbool.h>
-
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 
 namespace ovsp4rt {
-
-//----------------------------------------------------------------------
-// Utility functions
-//----------------------------------------------------------------------
-
-extern std::string EncodeByteValue(int arg_count...);
-
-extern int GetActionId(const ::p4::config::v1::P4Info& p4info,
-                       const std::string& a_name);
-
-extern int GetTableId(const ::p4::config::v1::P4Info& p4info,
-                      const std::string& t_name);
 
 //----------------------------------------------------------------------
 // Common functions

--- a/ovs-p4rt/sidecar/ovsp4rt_util_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_util_int.h
@@ -1,0 +1,31 @@
+// Copyright 2022-2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Private utility functions.
+
+#ifndef OVSP4RT_UTIL_INT_H_
+#define OVSP4RT_UTIL_INT_H_
+
+#include <stdarg.h>
+
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+
+namespace ovsp4rt {
+
+//----------------------------------------------------------------------
+// Utility functions
+//----------------------------------------------------------------------
+
+extern std::string EncodeByteValue(int arg_count...);
+
+extern int GetActionId(const ::p4::config::v1::P4Info& p4info,
+                       const std::string& a_name);
+
+extern int GetTableId(const ::p4::config::v1::P4Info& p4info,
+                      const std::string& t_name);
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_UTIL_INT_H_

--- a/ovs-p4rt/sidecar/tests/encode_host_port_value_test.cc
+++ b/ovs-p4rt/sidecar/tests/encode_host_port_value_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
 #include <arpa/inet.h>
@@ -8,7 +9,7 @@
 
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_util_int.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/base_tunnel_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/base_tunnel_info_test.cc
@@ -8,7 +8,7 @@
 
 #include "es2k/p4_name_mapping.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"  // GetTableId
+#include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_prep_fdb_tunnel_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_prep_fdb_tunnel_table_test.cc
@@ -11,6 +11,7 @@
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
+#include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_update_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_update_src_port_test.cc
@@ -10,7 +10,7 @@
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
-#include "ovsp4rt_private.h"  // EncodeByteValue
+#include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_fdb_entry_test.cc
@@ -10,7 +10,7 @@
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_doconfig_int.h"
-#include "ovsp4rt_private.h"  // EncodeByteValue
+#include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_src_port_entry_test.cc
@@ -12,7 +12,7 @@
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_doconfig_int.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"


### PR DESCRIPTION
- Moved function prototypes for ovsp4rt utility functions from `ovsp4rt_private.h` to `ovsp4rt_util_int.h`.