### PR TITLE
Define Es2kPrepDecapTableTest

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -1560,7 +1560,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 #endif  // ES2K_TARGET
 
 #if defined(ES2K_TARGET)
-void Es2kPrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
+void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
                                 const struct tunnel_info& tunnel_info,
                                 const ::p4::config::v1::P4Info& p4info,
                                 bool insert_entry) {
@@ -1647,6 +1647,8 @@ void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
+// called-by: Es2kPrepareDecapTableEntry
+// port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED
 void PrepareDecapModTableEntry(p4::v1::TableEntry* table_entry,
                                const struct tunnel_info& tunnel_info,
                                const ::p4::config::v1::P4Info& p4info,
@@ -1662,6 +1664,7 @@ void PrepareDecapModTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
+// called-by: PrepareDecapModAndVlanPushTableEntry
 void PrepareVxlanDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -1706,6 +1709,7 @@ void PrepareVxlanDecapModAndVlanPushTableEntry(
   }
 }
 
+// called-by: PrepareDecapModAndVlanPushTableEntry
 void PrepareGeneveDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -1750,6 +1754,8 @@ void PrepareGeneveDecapModAndVlanPushTableEntry(
   }
 }
 
+// called-by: Es2kPrepareDecapTableEntry
+// port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED
 void PrepareDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -1764,6 +1770,19 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
+// called-by: ConfigDecapTableEntry
+void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
+  if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED) {
+    PrepareDecapModTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  } else {
+    PrepareDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
+                                         insert_entry);
+  }
+}
+
 // called-by: DoConfigTunnelEntry (es2k)
 absl::Status ConfigDecapTableEntry(ClientInterface& client,
                                    const struct tunnel_info& tunnel_info,
@@ -1774,12 +1793,7 @@ absl::Status ConfigDecapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED) {
-    PrepareDecapModTableEntry(table_entry, tunnel_info, p4info, insert_entry);
-  } else {
-    PrepareDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
-                                         insert_entry);
-  }
+  Es2kPrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -51,7 +51,13 @@ extern void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 //----------------------------------------------------------------------
 
 #if defined(ES2K_TARGET)
-extern void Es2kPrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
+
+extern void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
+
+extern void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
                                        const struct tunnel_info& tunnel_info,
                                        const ::p4::config::v1::P4Info& p4info,
                                        bool insert_entry);

--- a/ovs-p4rt/sidecar/tests/es2k/base_tunnel_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/base_tunnel_info_test.cc
@@ -6,7 +6,6 @@
 #include <arpa/inet.h>
 #include <gtest/gtest.h>
 
-#include "es2k/p4_name_mapping.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
@@ -99,54 +98,6 @@ void BaseTunnelInfoTest::InitP4Info(::p4::config::v1::P4Info* p4info) {
   auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
   EXPECT_TRUE(status.ok()) << "ParseProtoFromString: "
                            << status.error_message();
-}
-
-void BaseTunnelInfoTest::AssertV4VxlanUntagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE);
-}
-
-void BaseTunnelInfoTest::AssertV4GeneveUntagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, GENEVE_ENCAP_VLAN_POP_MOD_TABLE);
-}
-
-void BaseTunnelInfoTest::AssertV4VxlanTagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, VXLAN_ENCAP_MOD_TABLE);
-}
-
-void BaseTunnelInfoTest::AssertV4GeneveTagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, GENEVE_ENCAP_MOD_TABLE);
-}
-
-void BaseTunnelInfoTest::AssertV6VxlanUntagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE);
-}
-
-void BaseTunnelInfoTest::AssertV6GeneveUntagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE);
-}
-
-void BaseTunnelInfoTest::AssertV6VxlanTagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, VXLAN_ENCAP_V6_MOD_TABLE);
-}
-
-void BaseTunnelInfoTest::AssertV6GeneveTagged(
-    const p4::v1::TableEntry& table_entry,
-    const ::p4::config::v1::P4Info& p4info) {
-  AssertTableId(table_entry, p4info, GENEVE_ENCAP_V6_MOD_TABLE);
 }
 
 void BaseTunnelInfoTest::AssertTableId(const p4::v1::TableEntry& table_entry,

--- a/ovs-p4rt/sidecar/tests/es2k/base_tunnel_info_test.h
+++ b/ovs-p4rt/sidecar/tests/es2k/base_tunnel_info_test.h
@@ -31,31 +31,6 @@ class BaseTunnelInfoTest : public ::testing::Test {
 
   static void InitP4Info(::p4::config::v1::P4Info* p4info);
 
-  static void AssertV4VxlanUntagged(const p4::v1::TableEntry& table_entry,
-                                    const ::p4::config::v1::P4Info& p4info);
-
-  static void AssertV4GeneveUntagged(const p4::v1::TableEntry& table_entry,
-                                     const ::p4::config::v1::P4Info& p4info);
-
-  static void AssertV4VxlanTagged(const p4::v1::TableEntry& table_entry,
-                                  const ::p4::config::v1::P4Info& p4info);
-
-  static void AssertV4GeneveTagged(const p4::v1::TableEntry& table_entry,
-                                   const ::p4::config::v1::P4Info& p4info);
-
-  static void AssertV6VxlanUntagged(const p4::v1::TableEntry& table_entry,
-                                    const ::p4::config::v1::P4Info& p4info);
-
-  static void AssertV6GeneveUntagged(const p4::v1::TableEntry& table_entry,
-                                     const ::p4::config::v1::P4Info& p4info);
-
-  static void AssertV6VxlanTagged(const p4::v1::TableEntry& table_entry,
-                                  const ::p4::config::v1::P4Info& p4info);
-
-  static void AssertV6GeneveTagged(const p4::v1::TableEntry& table_entry,
-                                   const ::p4::config::v1::P4Info& p4info);
-
- private:
   static void AssertTableId(const p4::v1::TableEntry& table_entry,
                             const ::p4::config::v1::P4Info& p4info,
                             const char* table_name);

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_prep_decap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_prep_decap_table_test.cc
@@ -1,0 +1,61 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#include "base_tunnel_info_test.h"
+#include "es2k/p4_name_mapping.h"
+#include "ovsp4rt_private.h"
+
+namespace ovsp4rt {
+
+class Es2kPrepDecapTableTest : public BaseTunnelInfoTest {
+ public:
+  Es2kPrepDecapTableTest() {}
+  virtual ~Es2kPrepDecapTableTest() = default;
+
+  static void AssertV4VxlanTagged(const p4::v1::TableEntry& table_entry,
+                                  const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, VXLAN_DECAP_MOD_TABLE);
+  }
+
+  static void AssertV4VxlanUntagged(const p4::v1::TableEntry& table_entry,
+                                    const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE);
+  }
+};
+
+// Es2kPrepareDecapTableEntry switches on port_vlan_mode.
+// IP version and tunnel type are irrelevant.
+
+TEST_F(Es2kPrepDecapTableTest, prepareDecapIpv4VxlanTagged) {
+  p4::v1::TableEntry table_entry;
+
+  struct tunnel_info tunnel_info = {0};
+  InitV4TunnelInfo(tunnel_info);
+  InitVxlanTagged(tunnel_info);
+
+  ::p4::config::v1::P4Info p4info;
+  InitP4Info(&p4info);
+
+  // port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED
+  Es2kPrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+
+  AssertV4VxlanTagged(table_entry, p4info);
+}
+
+TEST_F(Es2kPrepDecapTableTest, prepareDecapV4VxlanUntagged) {
+  p4::v1::TableEntry table_entry;
+
+  struct tunnel_info tunnel_info = {0};
+  InitV4TunnelInfo(tunnel_info);
+  InitVxlanUntagged(tunnel_info);
+
+  ::p4::config::v1::P4Info p4info;
+  InitP4Info(&p4info);
+
+  // port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED
+  Es2kPrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+
+  AssertV4VxlanUntagged(table_entry, p4info);
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_prep_encap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_prep_encap_table_test.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "base_tunnel_info_test.h"
+#include "es2k/p4_name_mapping.h"
 #include "ovsp4rt_private.h"
 
 namespace ovsp4rt {
@@ -10,6 +11,46 @@ class Es2kPrepEncapTableTest : public BaseTunnelInfoTest {
  public:
   Es2kPrepEncapTableTest() {}
   virtual ~Es2kPrepEncapTableTest() = default;
+
+  static void AssertV4VxlanUntagged(const p4::v1::TableEntry& table_entry,
+                                    const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE);
+  }
+
+  static void AssertV4GeneveUntagged(const p4::v1::TableEntry& table_entry,
+                                     const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, GENEVE_ENCAP_VLAN_POP_MOD_TABLE);
+  }
+
+  static void AssertV4VxlanTagged(const p4::v1::TableEntry& table_entry,
+                                  const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, VXLAN_ENCAP_MOD_TABLE);
+  }
+
+  static void AssertV4GeneveTagged(const p4::v1::TableEntry& table_entry,
+                                   const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, GENEVE_ENCAP_MOD_TABLE);
+  }
+
+  static void AssertV6VxlanUntagged(const p4::v1::TableEntry& table_entry,
+                                    const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE);
+  }
+
+  static void AssertV6GeneveUntagged(const p4::v1::TableEntry& table_entry,
+                                     const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE);
+  }
+
+  static void AssertV6VxlanTagged(const p4::v1::TableEntry& table_entry,
+                                  const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, VXLAN_ENCAP_V6_MOD_TABLE);
+  }
+
+  static void AssertV6GeneveTagged(const p4::v1::TableEntry& table_entry,
+                                   const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, GENEVE_ENCAP_V6_MOD_TABLE);
+  }
 };
 
 //----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_tunnel_info_tests.cmake
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_tunnel_info_tests.cmake
@@ -44,7 +44,7 @@ macro(define_es2k_tunnel_info_test TARGET)
   list(APPEND UNIT_TEST_NAMES ${TARGET})
 endmacro()
 
-#define_es2k_tunnel_info_test(es2k_config_decap_table_test)
+define_es2k_tunnel_info_test(es2k_prep_decap_table_test)
 define_es2k_tunnel_info_test(es2k_prep_encap_table_test)
 #define_es2k_tunnel_info_test(es2k_config_tunnel_term_test)
 


### PR DESCRIPTION
- Extracted `Es2kPrepareDecapTableEntry()` from `PrepareDecapTableEntry()`, to make it testable.

- Moved Assert methods from `BaseTunnelInfoTest` to `Es2kPrepEncapTableTest`.

- Implemented `Es2kPrepDecapTableTest`.