### PR TITLE
ConfigTunnelTermTableEntry unit tests

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -2200,6 +2200,21 @@ absl::Status ConfigRxTunnelSrcPortTableEntry(
   return client.sendWriteRequest(write_request);
 }
 
+// called-by: ConfigTunnelTermTableEntry
+void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                     const struct tunnel_info& tunnel_info,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
+  if (tunnel_info.local_ip.family == AF_INET &&
+      tunnel_info.remote_ip.family == AF_INET) {
+    PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  } else if (tunnel_info.local_ip.family == AF_INET6 &&
+             tunnel_info.remote_ip.family == AF_INET6) {
+    PrepareV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
+                                  insert_entry);
+  }
+}
+
 #endif  // ES2K_TARGET
 
 // called-by: DoConfigTunnelEntry (common)
@@ -2211,18 +2226,12 @@ absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
   ::p4::v1::TableEntry* table_entry;
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
+
 #if defined(DPDK_TARGET)
   PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
-
 #elif defined(ES2K_TARGET)
-  if (tunnel_info.local_ip.family == AF_INET &&
-      tunnel_info.remote_ip.family == AF_INET) {
-    PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
-  } else if (tunnel_info.local_ip.family == AF_INET6 &&
-             tunnel_info.remote_ip.family == AF_INET6) {
-    PrepareV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
+  Es2kPrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info,
                                   insert_entry);
-  }
 #else
 #error "ASSERT: Unknown TARGET type!"
 #endif

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -15,19 +15,23 @@
 
 namespace ovsp4rt {
 
+extern absl::Status ConfigTunnelTermTableEntry(
+    ClientInterface& client, const struct tunnel_info& tunnel_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
 #if defined(ES2K_TARGET)
 
 extern absl::Status ConfigDstIpMacMapTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigFdbUpdateSrcPort(
-    ClientInterface& client, struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info);
-
 extern absl::Status ConfigEncapTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern absl::Status ConfigFdbUpdateSrcPort(
+    ClientInterface& client, struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info);
 
 extern void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
                                       struct mac_learning_info& learn_info,

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -69,6 +69,10 @@ extern void Es2kPrepareFdbTunnelTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
+extern void Es2kPrepareTunnelTermTableEntry(
+    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
 extern void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
                                          const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,

--- a/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
@@ -1,0 +1,68 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for ConfigTunnelTermTableEntry (common)
+
+// Core functionality is handled by PrepareL2ToTunnelV4(),
+// which is tested separately. This is a test of the non-core
+// functionality.
+
+#include <absl/status/status.h>
+
+// clang-format off
+#include <gtest/gtest.h>    // must precede gmock.h
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "base_tunnel_info_test.h"
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt_config_int.h"
+
+using ::testing::Return;
+
+namespace ovsp4rt {
+
+class ConfigTunnelTermEntryTest : public BaseTunnelInfoTest {
+public:
+  ConfigTunnelTermEntryTest() {}
+  virtual ~ConfigTunnelTermEntryTest() = default;
+};
+
+TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntryFailure) {
+  constexpr char ERROR_MESSAGE[] = "sendWriteRequest failed";
+  struct tunnel_info tunnel_info = {0};
+  InitV4TunnelInfo(tunnel_info);
+  InitVxlanUntagged(tunnel_info);
+
+  ::p4::config::v1::P4Info p4info;
+  InitP4Info(&p4info);
+
+  TestClientMock client;
+  EXPECT_CALL(client, sendWriteRequest)
+      .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
+
+  auto status =
+      ConfigTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE) << status;
+}
+
+TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntrySuccess) {
+  struct tunnel_info tunnel_info = {0};
+  InitV4TunnelInfo(tunnel_info);
+  InitVxlanTagged(tunnel_info);
+
+  ::p4::config::v1::P4Info p4info;
+  InitP4Info(&p4info);
+
+  TestClientMock client;
+  EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
+
+  auto status =
+      ConfigTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+
+  ASSERT_TRUE(status.ok()) << status;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
@@ -23,7 +23,7 @@ using ::testing::Return;
 namespace ovsp4rt {
 
 class ConfigTunnelTermEntryTest : public BaseTunnelInfoTest {
-public:
+ public:
   ConfigTunnelTermEntryTest() {}
   virtual ~ConfigTunnelTermEntryTest() = default;
 };
@@ -45,7 +45,8 @@ TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntryFailure) {
       ConfigTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
-  ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE) << status;
+  ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
+      << status;
 }
 
 TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntrySuccess) {

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_prep_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_prep_tunnel_term_entry_test.cc
@@ -1,0 +1,62 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for Es2kPrepareTunnelTermTableEntry().
+
+#include <gtest/gtest.h>
+
+#include "base_tunnel_info_test.h"
+#include "es2k/p4_name_mapping.h"
+#include "ovsp4rt_private.h"
+
+namespace ovsp4rt {
+
+class Es2kPrepTunnelTermEntryTest : public BaseTunnelInfoTest {
+ public:
+  Es2kPrepTunnelTermEntryTest() {}
+  virtual ~Es2kPrepTunnelTermEntryTest() = default;
+
+  static void AssertV4Tunnel(const p4::v1::TableEntry& table_entry,
+                             const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, IPV4_TUNNEL_TERM_TABLE);
+  }
+
+  static void AssertV6Tunnel(const p4::v1::TableEntry& table_entry,
+                             const ::p4::config::v1::P4Info& p4info) {
+    AssertTableId(table_entry, p4info, IPV6_TUNNEL_TERM_TABLE);
+  }
+};
+
+TEST_F(Es2kPrepTunnelTermEntryTest, configV4TunnelTermEntry) {
+  ::p4::v1::TableEntry table_entry;
+
+  struct tunnel_info tunnel_info = {0};
+  InitV4TunnelInfo(tunnel_info);
+  InitVxlanTagged(tunnel_info);
+
+  ::p4::config::v1::P4Info p4info;
+  InitP4Info(&p4info);
+
+  Es2kPrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info,
+                                  INSERT_ENTRY);
+
+  AssertV4Tunnel(table_entry, p4info);
+}
+
+TEST_F(Es2kPrepTunnelTermEntryTest, configV6TunnelTermEntry) {
+  ::p4::v1::TableEntry table_entry;
+
+  struct tunnel_info tunnel_info = {0};
+  InitV6TunnelInfo(tunnel_info);
+  InitVxlanTagged(tunnel_info);
+
+  ::p4::config::v1::P4Info p4info;
+  InitP4Info(&p4info);
+
+  Es2kPrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info,
+                                  INSERT_ENTRY);
+
+  AssertV6Tunnel(table_entry, p4info);
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_tunnel_info_tests.cmake
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_tunnel_info_tests.cmake
@@ -45,6 +45,8 @@ macro(define_es2k_tunnel_info_test TARGET)
 endmacro()
 
 define_es2k_tunnel_info_test(config_encap_table_entry_test)
+define_es2k_tunnel_info_test(config_tunnel_term_entry_test)
 define_es2k_tunnel_info_test(es2k_prep_decap_table_test)
 define_es2k_tunnel_info_test(es2k_prep_encap_table_test)
+define_es2k_tunnel_info_test(es2k_prep_tunnel_term_entry_test)
 

--- a/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v4_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v4_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetL2ToTunnelV4TableEntry().
 
-// Core functionality is handled by PrepareL2ToTunnelV4(),
+// Core functionality is handled by Es2kPrepareTunnelTermTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 


### PR DESCRIPTION
- Extracted `Es2kPrepareRxTunnelTableEntry` from `ConfigRxTunnelTableEntry` to make it testable.

- Defined unit test for `Es2kPrepareRxTunnelTableEntry`.

- Defined unit test for `ConfigRxTunnelTableEntry`.