### PR TITLE
Ensure that gtest.h always precedes gmock.h

### DIFF
--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_fdb_entry_test.cc
@@ -4,8 +4,11 @@
 // Unit test for DPDK version of DoConfigFdbEntry().
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_config_tunnel_entry_test.cc
@@ -5,9 +5,12 @@
 
 #include <absl/status/status.h>
 #include <arpa/inet.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
@@ -10,7 +10,7 @@
 #include <absl/status/status.h>
 
 // clang-format off
-#include <gtest/gtest.h>    // must precede gmock.h
+#include <gtest/gtest.h>
 #include <gmock/gmock.h>
 // clang-format on
 

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_config_dst_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_config_dst_ip_mac_map_test.cc
@@ -5,8 +5,11 @@
 // Unit test for ConfigDstIpMacMapTableEntry(). [es2k]
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "base_mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_config_src_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_config_src_ip_mac_map_test.cc
@@ -5,8 +5,11 @@
 // Unit test for ConfigSrcIpMacMapTableEntry(). [es2k]
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "base_mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_update_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_update_src_port_test.cc
@@ -4,8 +4,11 @@
 // Unit test for ConfigFdbUpdateSrcPort() [ES2K]
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_update_tunnel_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_update_tunnel_info_test.cc
@@ -4,8 +4,11 @@
 // Unit test for ConfigFdbUpdateTunnelInfo() [ES2K]
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_fdb_entry_test.cc
@@ -4,8 +4,11 @@
 // Unit test for ES2K version of DoConfigFdbEntry().
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_ip_mac_map_test.cc
@@ -5,8 +5,11 @@
 
 #include <absl/status/status.h>
 #include <arpa/inet.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_rx_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_rx_tunnel_src_port_test.cc
@@ -5,8 +5,11 @@
 
 #include <absl/status/status.h>
 #include <arpa/inet.h>
-#include <gmock/gmock.h>
+
+// clang-format off
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_src_port_entry_test.cc
@@ -4,9 +4,12 @@
 // Unit test for ES2K version of DoConfigTunnelEntry().
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "absl/status/statusor.h"
 #include "client/ovsp4rt_test_client_mock.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_entry_test.cc
@@ -5,9 +5,12 @@
 
 #include <absl/status/status.h>
 #include <arpa/inet.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_src_port_test.cc
@@ -4,9 +4,12 @@
 // Unit test for DoConfigSrcPortEntry().
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_vlan_entry_test.cc
@@ -4,9 +4,12 @@
 // Unit test for ES2K version of DoConfigVlanEntry().
 
 #include <absl/status/status.h>
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
 
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"


### PR DESCRIPTION
- Bracketed all #includes for gtest.h and gmock.h with directives to ensure that clang-format does not reorder them.