### PR TITLE
Define generic DoConfigEntry tests

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -2435,6 +2435,24 @@ absl::Status ConfigFdbVlanEntry(ClientInterface& client,
 // learn_info is passed by value because this function may make local
 // modifications to it.
 //----------------------------------------------------------------------
+
+// extracted from DoConfigFdbEntry (testability)
+absl::Status ConfigFdbEntry(ClientInterface& client,
+                            struct mac_learning_info learn_info,
+                            const ::p4::config::v1::P4Info& p4info,
+                            bool insert_entry) {
+  if (!insert_entry) {
+    // updates learn_info
+    ConfigFdbUpdateTunnelInfo(client, learn_info, p4info);
+  }
+
+  if (learn_info.is_tunnel) {
+    return ConfigFdbTunnelEntry(client, learn_info, insert_entry, p4info);
+  } else {
+    return ConfigFdbVlanEntry(client, learn_info, insert_entry, p4info);
+  }
+}
+
 absl::Status DoConfigFdbEntry(ClientInterface& client,
                               struct mac_learning_info learn_info,
                               bool insert_entry, const char* grpc_addr) {
@@ -2449,20 +2467,14 @@ absl::Status DoConfigFdbEntry(ClientInterface& client,
   status = client.getPipelineConfig(&p4info);
   if (!status.ok()) return status;
 
-  if (!insert_entry) {
-    ConfigFdbUpdateTunnelInfo(client, learn_info, p4info);
-  }
-
-  if (learn_info.is_tunnel) {
-    return ConfigFdbTunnelEntry(client, learn_info, insert_entry, p4info);
-  } else {
-    return ConfigFdbVlanEntry(client, learn_info, insert_entry, p4info);
-  }
+  // Update P4 tables.
+  return ConfigFdbEntry(client, learn_info, p4info, insert_entry);
 }
 
 //----------------------------------------------------------------------
 // DoConfigRxTunnelSrcEntry (ES2K)
 //----------------------------------------------------------------------
+
 absl::Status DoConfigRxTunnelSrcEntry(ClientInterface& client,
                                       const struct tunnel_info& tunnel_info,
                                       bool insert_entry,
@@ -2478,6 +2490,7 @@ absl::Status DoConfigRxTunnelSrcEntry(ClientInterface& client,
   status = client.getPipelineConfig(&p4info);
   if (!status.ok()) return status;
 
+  // Update P4 tables.
   return ConfigRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
                                          insert_entry);
 }
@@ -2485,6 +2498,22 @@ absl::Status DoConfigRxTunnelSrcEntry(ClientInterface& client,
 //----------------------------------------------------------------------
 // DoConfigTunnelSrcPortEntry (ES2K)
 //----------------------------------------------------------------------
+
+// extracted from DoConfigTunnelSrcPortEntry (testability)
+absl::Status ConfigTunnelSrcPortEntry(ClientInterface& client,
+                                      const struct src_port_info& tnl_sp,
+                                      const ::p4::config::v1::P4Info& p4info,
+                                      bool insert_entry) {
+  ::p4::v1::WriteRequest write_request;
+  ::p4::v1::TableEntry* table_entry;
+
+  table_entry = client.initWriteRequest(&write_request, insert_entry);
+
+  PrepareSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
+
+  return client.sendWriteRequest(write_request);
+}
+
 absl::Status DoConfigTunnelSrcPortEntry(ClientInterface& client,
                                         const struct src_port_info& tnl_sp,
                                         bool insert_entry,
@@ -2500,14 +2529,8 @@ absl::Status DoConfigTunnelSrcPortEntry(ClientInterface& client,
   status = client.getPipelineConfig(&p4info);
   if (!status.ok()) return status;
 
-  ::p4::v1::WriteRequest write_request;
-  ::p4::v1::TableEntry* table_entry;
-
-  table_entry = client.initWriteRequest(&write_request, insert_entry);
-
-  PrepareSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
-
-  return client.sendWriteRequest(write_request);
+  // Update P4 tables.
+  return ConfigTunnelSrcPortEntry(client, tnl_sp, p4info, insert_entry);
 }
 
 //----------------------------------------------------------------------
@@ -2516,24 +2539,13 @@ absl::Status DoConfigTunnelSrcPortEntry(ClientInterface& client,
 // vsi_sp is passed by value because this function makes local
 // modifications to it.
 //----------------------------------------------------------------------
-absl::Status DoConfigSrcPortEntry(ClientInterface& client,
-                                  struct src_port_info vsi_sp,
-                                  bool insert_entry, const char* grpc_addr) {
-  absl::Status status;
 
-  // Start a new client session.
-  status = client.connect(grpc_addr);
-  if (!status.ok()) return status;
-
-  // Fetch P4Info object from server.
-  ::p4::config::v1::P4Info p4info;
-  status = client.getPipelineConfig(&p4info);
-  if (!status.ok()) return status;
-
+// extracted from DoConfigSrcPortEntry (testability)
+absl::Status ConfigSrcPortEntry(ClientInterface& client,
+                                struct src_port_info vsi_sp,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   // TODO(derek): refactor (extract method)
-  //
-  // GetVsiSrcPort(ClientInterface& client, const P4Info& p4info,
-  //               uint32_t src_port, uint32_t& vsi_port);
   auto response_or_status =
       GetTxAccVsiTableEntry(client, vsi_sp.src_port, p4info);
   if (!response_or_status.ok()) return response_or_status.status();
@@ -2570,9 +2582,40 @@ absl::Status DoConfigSrcPortEntry(ClientInterface& client,
   return ConfigVsiSrcPortTableEntry(client, vsi_sp, p4info, insert_entry);
 }
 
+absl::Status DoConfigSrcPortEntry(ClientInterface& client,
+                                  struct src_port_info vsi_sp,
+                                  bool insert_entry, const char* grpc_addr) {
+  absl::Status status;
+
+  // Start a new client session.
+  status = client.connect(grpc_addr);
+  if (!status.ok()) return status;
+
+  // Fetch P4Info object from server.
+  ::p4::config::v1::P4Info p4info;
+  status = client.getPipelineConfig(&p4info);
+  if (!status.ok()) return status;
+
+  // Update P4 tables.
+  return ConfigSrcPortEntry(client, vsi_sp, p4info, insert_entry);
+}
+
 //----------------------------------------------------------------------
 // DoConfigVlanEntry (ES2K)
 //----------------------------------------------------------------------
+
+// extracted from DoConfigVlanEntry (testability)
+absl::Status ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry) {
+  absl::Status status;
+
+  status = ConfigVlanPushTableEntry(client, vlan_id, p4info, insert_entry);
+  if (!status.ok()) return status;
+
+  return ConfigVlanPopTableEntry(client, vlan_id, p4info, insert_entry);
+}
+
 absl::Status DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
                                bool insert_entry, const char* grpc_addr) {
   absl::Status status;
@@ -2586,10 +2629,8 @@ absl::Status DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
   status = client.getPipelineConfig(&p4info);
   if (!status.ok()) return status;
 
-  status = ConfigVlanPushTableEntry(client, vlan_id, p4info, insert_entry);
-  if (!status.ok()) return status;
-
-  return ConfigVlanPopTableEntry(client, vlan_id, p4info, insert_entry);
+  // Update P4 tables.
+  return ConfigVlanEntry(client, vlan_id, p4info, insert_entry);
 }
 
 #elif defined(DPDK_TARGET)
@@ -2597,6 +2638,26 @@ absl::Status DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
 //----------------------------------------------------------------------
 // DoConfigFdbEntry (DPDK)
 //----------------------------------------------------------------------
+
+// extracted from DoConfigFdbEntry (testability)
+absl::Status ConfigFdbEntry(ClientInterface& client,
+                            const struct mac_learning_info& learn_info,
+                            const ::p4::config::v1::P4Info& p4info,
+                            bool insert_entry) {
+  if (learn_info.is_tunnel) {
+    return ConfigFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
+  } else if (learn_info.is_vlan) {
+    auto status =
+        ConfigFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
+    if (!status.ok()) return status;
+
+    return ConfigFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
+  } else {
+    // TODO(Derek): return error status?
+    return absl::OkStatus();
+  }
+}
+
 absl::Status DoConfigFdbEntry(ClientInterface& client,
                               struct mac_learning_info learn_info,
                               bool insert_entry, const char* grpc_addr) {
@@ -2611,18 +2672,8 @@ absl::Status DoConfigFdbEntry(ClientInterface& client,
   status = client.getPipelineConfig(&p4info);
   if (!status.ok()) return status;
 
-  if (learn_info.is_tunnel) {
-    status =
-        ConfigFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
-  } else if (learn_info.is_vlan) {
-    status =
-        ConfigFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
-    if (!status.ok()) return status;
-
-    status =
-        ConfigFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
-  }
-  return status;
+  // Update P4 tables.
+  return ConfigFdbEntry(client, learn_info, p4info, insert_entry);
 }
 
 #endif  // DPDK_TARGET
@@ -2630,6 +2681,25 @@ absl::Status DoConfigFdbEntry(ClientInterface& client,
 //----------------------------------------------------------------------
 // DoConfigTunnelEntry (common)
 //----------------------------------------------------------------------
+
+// extracted from DoConfigTunnelEntry (testability)
+absl::Status ConfigTunnelEntry(ClientInterface& client,
+                               const struct tunnel_info& tunnel_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry) {
+  absl::Status status;
+
+  status = ConfigEncapTableEntry(client, tunnel_info, p4info, insert_entry);
+  if (!status.ok()) return status;
+
+#if defined(ES2K_TARGET)
+  status = ConfigDecapTableEntry(client, tunnel_info, p4info, insert_entry);
+  if (!status.ok()) return status;
+#endif
+
+  return ConfigTunnelTermTableEntry(client, tunnel_info, p4info, insert_entry);
+}
+
 absl::Status DoConfigTunnelEntry(ClientInterface& client,
                                  const struct tunnel_info& tunnel_info,
                                  bool insert_entry, const char* grpc_addr) {
@@ -2644,15 +2714,8 @@ absl::Status DoConfigTunnelEntry(ClientInterface& client,
   status = client.getPipelineConfig(&p4info);
   if (!status.ok()) return status;
 
-  status = ConfigEncapTableEntry(client, tunnel_info, p4info, insert_entry);
-  if (!status.ok()) return status;
-
-#if defined(ES2K_TARGET)
-  status = ConfigDecapTableEntry(client, tunnel_info, p4info, insert_entry);
-  if (!status.ok()) return status;
-#endif
-
-  return ConfigTunnelTermTableEntry(client, tunnel_info, p4info, insert_entry);
+  // Update P4 tables.
+  return ConfigTunnelEntry(client, tunnel_info, p4info, insert_entry);
 }
 
 #if defined(ES2K_TARGET)
@@ -2660,20 +2723,12 @@ absl::Status DoConfigTunnelEntry(ClientInterface& client,
 //----------------------------------------------------------------------
 // DoConfigIpMacMapEntry (ES2K)
 //----------------------------------------------------------------------
-absl::Status DoConfigIpMacMapEntry(ClientInterface& client,
-                                   const struct ip_mac_map_info& ip_info,
-                                   bool insert_entry, const char* grpc_addr) {
-  absl::Status status;
 
-  // Start a new client session.
-  status = client.connect(grpc_addr);
-  if (!status.ok()) return status;
-
-  // Fetch P4Info object from server.
-  ::p4::config::v1::P4Info p4info;
-  status = client.getPipelineConfig(&p4info);
-  if (!status.ok()) return status;
-
+// extracted from DoConfigIpMacMapEntry (testability)
+absl::Status ConfigIpMacMapEntry(ClientInterface& client,
+                                 const struct ip_mac_map_info& ip_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry) {
   if (insert_entry) {
     auto status_or_read_response = GetVmSrcTableEntry(client, ip_info, p4info);
     if (status_or_read_response.ok()) {
@@ -2699,6 +2754,24 @@ try_dstip:
     (void)ConfigDstIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
   }
   return absl::OkStatus();
+}
+
+absl::Status DoConfigIpMacMapEntry(ClientInterface& client,
+                                   const struct ip_mac_map_info& ip_info,
+                                   bool insert_entry, const char* grpc_addr) {
+  absl::Status status;
+
+  // Start a new client session.
+  status = client.connect(grpc_addr);
+  if (!status.ok()) return status;
+
+  // Fetch P4Info object from server.
+  ::p4::config::v1::P4Info p4info;
+  status = client.getPipelineConfig(&p4info);
+  if (!status.ok()) return status;
+
+  // Update P4 tables.
+  return ConfigIpMacMapEntry(client, ip_info, p4info, insert_entry);
 }
 
 #endif  // ES2K_TARGET

--- a/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
@@ -171,6 +171,14 @@ define_es2k_config_test(config_vsi_src_port_entry_test)
 define_es2k_config_test(get_l2_to_tunnel_v4_entry_test)
 
 # ::testing::Test subclasses
+define_es2k_config_test(do_config_fdb_entry_test)
+define_es2k_config_test(do_config_ip_mac_map_test)
+define_es2k_config_test(do_config_rx_tunnel_src_port_test)
+define_es2k_config_test(do_config_src_port_entry_test)
+define_es2k_config_test(do_config_tunnel_entry_test)
+define_es2k_config_test(do_config_tunnel_src_port_test)
+define_es2k_config_test(do_config_vlan_entry_test)
+
 define_es2k_config_test(es2k_update_src_port_test)
 define_es2k_config_test(es2k_update_tunnel_info_test)
 

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_fdb_entry_test.cc
@@ -36,8 +36,7 @@ class DoConfigFdbEntryTest : public ::testing::Test {
 
   void InitP4Info(::p4::config::v1::P4Info* p4info) {
     auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status;
+    EXPECT_TRUE(status.ok()) << "ParseProtoFromString: " << status;
   }
 
   static absl::StatusOr<::p4::v1::ReadResponse> VsiLookupResponse() {

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_fdb_entry_test.cc
@@ -1,0 +1,106 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal unit test for DoConfigFdbEntry().
+
+#include <absl/status/status.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "ovsp4rt_util_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::DoAll;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr bool DELETE_ENTRY = false;
+constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
+
+class DoConfigFdbEntryTest : public ::testing::Test {
+ protected:
+  DoConfigFdbEntryTest() {}
+  virtual ~DoConfigFdbEntryTest() = default;
+
+  void InitP4Info(::p4::config::v1::P4Info* p4info) {
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+    EXPECT_TRUE(status.ok())
+        << "ParseProtoFromString: " << status;
+  }
+
+  static absl::StatusOr<::p4::v1::ReadResponse> VsiLookupResponse() {
+    constexpr int TABLE_ID = 42508227;   // tx_acc_vsi
+    constexpr int ACTION_ID = 31624713;  // l2_fwd_and_bypass_bridge
+    constexpr int PARAM_ID = 1;          // port
+
+    ::p4::v1::ReadResponse response;
+    auto entity = response.add_entities();
+
+    auto table_entry = entity->mutable_table_entry();
+    table_entry->set_table_id(TABLE_ID);
+
+    auto table_action = table_entry->mutable_action();
+
+    auto action = table_action->mutable_action();
+    action->set_action_id(ACTION_ID);
+
+    auto param = action->add_params();
+    param->set_param_id(PARAM_ID);
+    param->set_value(EncodeByteValue(4, 0, 0, 0, 72));
+
+    return response;
+  }
+};
+
+/**
+ * Exercises client.connect() error path.
+ */
+TEST_F(DoConfigFdbEntryTest, connectFailure) {
+  constexpr char CONNECT_ERROR[] = "connect";
+
+  struct mac_learning_info learn_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect)
+      .WillOnce(Return(absl::InternalError(CONNECT_ERROR)));
+
+  auto status = DoConfigFdbEntry(client, learn_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == CONNECT_ERROR)
+      << status;
+}
+
+/**
+ * Exercises config.getPipelineConfig() error path.
+ */
+TEST_F(DoConfigFdbEntryTest, getPipelineConfigFailure) {
+  constexpr char PIPELINE_ERROR[] = "getPipelineConfig";
+
+  struct mac_learning_info learn_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError(PIPELINE_ERROR)));
+
+  auto status = DoConfigFdbEntry(client, learn_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == PIPELINE_ERROR)
+      << status;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_ip_mac_map_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal unit test for DoConfigIpMacMapEntry().
+
+#include <absl/status/status.h>
+#include <arpa/inet.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_config_int.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
+
+class DoConfigIpMacMapTest : public ::testing::Test {
+ protected:
+  DoConfigIpMacMapTest() {}
+  virtual ~DoConfigIpMacMapTest() = default;
+
+  void InitIpv4MapInfo(struct ip_mac_map_info& map_info) {
+    constexpr uint8_t SRC_MAC[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    constexpr char IPV4_SRC_ADDR[] = "10.20.30.40";
+    constexpr int IPV4_PREFIX_LEN = 24;
+
+    memcpy(map_info.src_mac_addr, SRC_MAC, sizeof(map_info.src_mac_addr));
+
+    EXPECT_EQ(inet_pton(AF_INET, IPV4_SRC_ADDR,
+                        &map_info.src_ip_addr.ip.v4addr.s_addr),
+              1)
+        << "Error converting " << IPV4_SRC_ADDR;
+    map_info.src_ip_addr.family = AF_INET;
+    map_info.src_ip_addr.prefix_len = IPV4_PREFIX_LEN;
+  }
+
+  void InitP4Info(::p4::config::v1::P4Info* p4info) {
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+    EXPECT_TRUE(status.ok())
+        << "ParseProtoFromString: " << status;
+  }
+
+  static absl::StatusOr<::p4::v1::ReadResponse> FoundReadRequest() {
+    ::p4::v1::ReadResponse response;
+    return response;
+  }
+
+  static absl::StatusOr<::p4::v1::ReadResponse> NotFoundReadRequest() {
+    return absl::NotFoundError("Entry not found");
+  }
+};
+
+/**
+ * Exercises client.connect() error path.
+ */
+TEST_F(DoConfigIpMacMapTest, connectFailure) {
+  constexpr char CONNECT_ERROR[] = "connect";
+
+  const struct ip_mac_map_info map_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect)
+      .WillOnce(Return(absl::InternalError(CONNECT_ERROR)));
+
+  auto status =
+      DoConfigIpMacMapEntry(client, map_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == CONNECT_ERROR)
+      << status;
+}
+
+/**
+ * Exercises config.getPipelineConfig() error path.
+ */
+TEST_F(DoConfigIpMacMapTest, getPipelineConfigFailure) {
+  constexpr char PIPELINE_ERROR[] = "getPipelineConfig";
+
+  const struct ip_mac_map_info map_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError(PIPELINE_ERROR)));
+
+  auto status =
+      DoConfigIpMacMapEntry(client, map_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == PIPELINE_ERROR)
+      << status;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_ip_mac_map_test.cc
@@ -52,8 +52,7 @@ class DoConfigIpMacMapTest : public ::testing::Test {
 
   void InitP4Info(::p4::config::v1::P4Info* p4info) {
     auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status;
+    EXPECT_TRUE(status.ok()) << "ParseProtoFromString: " << status;
   }
 
   static absl::StatusOr<::p4::v1::ReadResponse> FoundReadRequest() {

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_rx_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_rx_tunnel_src_port_test.cc
@@ -1,0 +1,113 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal unit test for DoConfigRxTunnelSrcEntry().
+
+#include <absl/status/status.h>
+#include <arpa/inet.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
+
+class DoConfigRxTunnelSrcPortTest : public ::testing::Test {
+ protected:
+  DoConfigRxTunnelSrcPortTest() {}
+  ~DoConfigRxTunnelSrcPortTest() = default;
+
+  void InitIpv4TunnelInfo(struct tunnel_info& tunnel_info) {
+    constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
+    constexpr int IPV4_PREFIX_LEN = 24;
+
+    EXPECT_EQ(inet_pton(AF_INET, IPV4_DST_ADDR,
+                        &tunnel_info.remote_ip.ip.v4addr.s_addr),
+              1)
+        << "Error converting " << IPV4_DST_ADDR;
+    tunnel_info.remote_ip.family = AF_INET;
+    tunnel_info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
+
+    tunnel_info.vni = 0x123;
+    tunnel_info.src_port = 99;
+  }
+
+  void InitIpv6TunnelInfo(struct tunnel_info& tunnel_info) {
+    constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
+    constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
+    constexpr int IPV6_PREFIX_LEN = 64;
+
+    EXPECT_EQ(inet_pton(AF_INET6, IPV6_DST_ADDR,
+                        &tunnel_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32),
+              1)
+        << "Error converting " << IPV6_DST_ADDR;
+    tunnel_info.remote_ip.prefix_len = IPV6_PREFIX_LEN;
+
+    tunnel_info.vni = 0x911;
+    tunnel_info.src_port = 0xFADE;
+  }
+
+  void InitP4Info(::p4::config::v1::P4Info* p4info) {
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+    EXPECT_TRUE(status.ok())
+        << "ParseProtoFromString: " << status;
+  }
+};
+
+/**
+ * Exercises client.connect() error path.
+ */
+TEST_F(DoConfigRxTunnelSrcPortTest, connectFailure) {
+  constexpr char CONNECT_ERROR[] = "connect";
+
+  struct tunnel_info tunnel_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect)
+      .WillOnce(Return(absl::InternalError(CONNECT_ERROR)));
+
+  auto status =
+      DoConfigRxTunnelSrcEntry(client, tunnel_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == CONNECT_ERROR)
+      << status;
+}
+
+/**
+ * Exercises config.getPipelineConfig() error path.
+ */
+TEST_F(DoConfigRxTunnelSrcPortTest, getPipelineConfigFailure) {
+  constexpr char PIPELINE_ERROR[] = "getPipelineConfig";
+
+  struct tunnel_info tunnel_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError(PIPELINE_ERROR)));
+
+  auto status =
+      DoConfigRxTunnelSrcEntry(client, tunnel_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == PIPELINE_ERROR)
+      << status;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_rx_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_rx_tunnel_src_port_test.cc
@@ -64,8 +64,7 @@ class DoConfigRxTunnelSrcPortTest : public ::testing::Test {
 
   void InitP4Info(::p4::config::v1::P4Info* p4info) {
     auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status;
+    EXPECT_TRUE(status.ok()) << "ParseProtoFromString: " << status;
   }
 };
 

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_src_port_entry_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal unit test for DoConfigTunnelEntry().
+
+#include <absl/status/status.h>
+#include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "absl/status/statusor.h"
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "ovsp4rt_util_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::DoAll;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
+
+class DoConfigSrcPortEntryTest : public ::testing::Test {
+ protected:
+  DoConfigSrcPortEntryTest() {}
+  virtual ~DoConfigSrcPortEntryTest() = default;
+
+  void InitSrcPortInfo(struct src_port_info& port_info) {
+    port_info.bridge_id = 42;
+    port_info.vlan_id = 0x123;
+    port_info.src_port = 0x1066;
+  }
+
+  void InitP4Info(::p4::config::v1::P4Info* p4info) {
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+    EXPECT_TRUE(status.ok())
+        << "ParseProtoFromString: " << status;
+  }
+
+  static absl::StatusOr<::p4::v1::ReadResponse> DummySendReadRequest() {
+    constexpr int TABLE_ID = 42508227;   // tx_acc_vsi
+    constexpr int ACTION_ID = 31624713;  // l2_fwd_and_bypass_bridge
+    constexpr int PARAM_ID = 1;          // port
+
+    ::p4::v1::ReadResponse response;
+    auto entity = response.add_entities();
+
+    auto table_entry = entity->mutable_table_entry();
+    table_entry->set_table_id(TABLE_ID);
+
+    auto table_action = table_entry->mutable_action();
+
+    auto action = table_action->mutable_action();
+    action->set_action_id(ACTION_ID);
+
+    auto param = action->add_params();
+    param->set_param_id(PARAM_ID);
+    param->set_value(EncodeByteValue(4, 0, 0, 0, 72));
+
+    return response;
+  }
+};
+
+/**
+ * Exercises client.connect() error path.
+ */
+TEST_F(DoConfigSrcPortEntryTest, connectFailure) {
+  struct src_port_info port_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::InternalError("connect")));
+
+  auto status =
+      DoConfigSrcPortEntry(client, port_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "connect")
+      << status;
+}
+
+/**
+ * Exercises config.getPipelineConfig() error path.
+ */
+TEST_F(DoConfigSrcPortEntryTest, getPipelineConfigFailure) {
+  struct src_port_info port_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError("getPipelineConfig")));
+
+  auto status =
+      DoConfigSrcPortEntry(client, port_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "getPipelineConfig")
+      << status;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_src_port_entry_test.cc
@@ -43,8 +43,7 @@ class DoConfigSrcPortEntryTest : public ::testing::Test {
 
   void InitP4Info(::p4::config::v1::P4Info* p4info) {
     auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status;
+    EXPECT_TRUE(status.ok()) << "ParseProtoFromString: " << status;
   }
 
   static absl::StatusOr<::p4::v1::ReadResponse> DummySendReadRequest() {
@@ -84,8 +83,7 @@ TEST_F(DoConfigSrcPortEntryTest, connectFailure) {
       DoConfigSrcPortEntry(client, port_info, INSERT_ENTRY, GRPC_ADDR);
 
   ASSERT_FALSE(status.ok());
-  ASSERT_TRUE(IsInternal(status) && status.message() == "connect")
-      << status;
+  ASSERT_TRUE(IsInternal(status) && status.message() == "connect") << status;
 }
 
 /**

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_entry_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal test for DoConfigTunnelEntry().
+
+#include <absl/status/status.h>
+#include <arpa/inet.h>
+#include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
+
+class DoConfigTunnelEntryTest : public ::testing::Test {
+ protected:
+  DoConfigTunnelEntryTest() {}
+  virtual ~DoConfigTunnelEntryTest() = default;
+
+  void InitIpv4TunnelInfo(struct tunnel_info& tunnel_info) {
+    constexpr char IPV4_SRC_ADDR[] = "10.20.30.40";
+    constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
+    constexpr int IPV4_PREFIX_LEN = 24;
+
+    constexpr uint16_t SRC_PORT = 0x1066;
+    constexpr uint16_t DST_PORT = 0x4224;
+
+    EXPECT_EQ(inet_pton(AF_INET, IPV4_SRC_ADDR,
+                        &tunnel_info.local_ip.ip.v4addr.s_addr),
+              1)
+        << "Error converting " << IPV4_SRC_ADDR;
+    tunnel_info.local_ip.prefix_len = IPV4_PREFIX_LEN;
+    tunnel_info.local_ip.family = AF_INET;
+
+    EXPECT_EQ(inet_pton(AF_INET, IPV4_DST_ADDR,
+                        &tunnel_info.remote_ip.ip.v4addr.s_addr),
+              1)
+        << "Error converting " << IPV4_DST_ADDR;
+    tunnel_info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
+    tunnel_info.remote_ip.family = AF_INET;
+
+    tunnel_info.src_port = SRC_PORT;
+    tunnel_info.dst_port = DST_PORT;
+  };
+
+  void InitVxlanTagged(struct tunnel_info& tunnel_info) {
+    tunnel_info.tunnel_type = OVS_TUNNEL_VXLAN;
+    tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
+    tunnel_info.vni = 0x1066;
+  }
+
+  void InitVxlanUntagged(struct tunnel_info& tunnel_info) {
+    tunnel_info.tunnel_type = OVS_TUNNEL_VXLAN;
+    tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
+    tunnel_info.vni = 0x1492;
+  }
+
+  void InitGeneveTagged(struct tunnel_info& tunnel_info) {
+    tunnel_info.tunnel_type = OVS_TUNNEL_GENEVE;
+    tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
+    tunnel_info.vni = 0x1776;
+  }
+
+  void InitGeneveUntagged(struct tunnel_info& tunnel_info) {
+    tunnel_info.tunnel_type = OVS_TUNNEL_GENEVE;
+    tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
+    tunnel_info.vni = 0x1984;
+  }
+
+  void InitP4Info(::p4::config::v1::P4Info* p4info) {
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+    EXPECT_TRUE(status.ok())
+        << "ParseProtoFromString: " << status.error_message();
+  }
+};
+
+/**
+ * Exercises client.connect() error path.
+ */
+TEST_F(DoConfigTunnelEntryTest, connectFailure) {
+  struct tunnel_info tunnel_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::InternalError("connect")));
+
+  auto status =
+      DoConfigTunnelEntry(client, tunnel_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "connect")
+      << status;
+}
+
+/**
+ * Exercises config.getPipelineConfig() error path.
+ */
+TEST_F(DoConfigTunnelEntryTest, getPipelineConfigFailure) {
+  struct tunnel_info tunnel_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError("getPipelineConfig")));
+
+  auto status =
+      DoConfigTunnelEntry(client, tunnel_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "getPipelineConfig")
+      << status;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_entry_test.cc
@@ -103,8 +103,7 @@ TEST_F(DoConfigTunnelEntryTest, connectFailure) {
       DoConfigTunnelEntry(client, tunnel_info, INSERT_ENTRY, GRPC_ADDR);
 
   ASSERT_FALSE(status.ok());
-  ASSERT_TRUE(IsInternal(status) && status.message() == "connect")
-      << status;
+  ASSERT_TRUE(IsInternal(status) && status.message() == "connect") << status;
 }
 
 /**

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_src_port_test.cc
@@ -40,8 +40,7 @@ class DoConfigTunnelSrcPortTest : public ::testing::Test {
 
   void InitP4Info(::p4::config::v1::P4Info* p4info) {
     auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status;
+    EXPECT_TRUE(status.ok()) << "ParseProtoFromString: " << status;
   }
 };
 
@@ -58,8 +57,7 @@ TEST_F(DoConfigTunnelSrcPortTest, connectFailure) {
       DoConfigTunnelSrcPortEntry(client, port_info, INSERT_ENTRY, GRPC_ADDR);
 
   ASSERT_FALSE(status.ok());
-  ASSERT_TRUE(IsInternal(status) && status.message() == "connect")
-      << status;
+  ASSERT_TRUE(IsInternal(status) && status.message() == "connect") << status;
 }
 
 /**

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_tunnel_src_port_test.cc
@@ -1,0 +1,84 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for DoConfigSrcPortEntry().
+
+#include <absl/status/status.h>
+#include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr char GRPC_ADDR[] = "172.54.19.3:5678";
+
+class DoConfigTunnelSrcPortTest : public ::testing::Test {
+ protected:
+  DoConfigTunnelSrcPortTest() {}
+  ~DoConfigTunnelSrcPortTest() = default;
+
+  void InitPortInfo(struct src_port_info& port_info) {
+    port_info.bridge_id = 42;
+    port_info.vlan_id = 0x123;
+    port_info.src_port = 0x1066;
+  }
+
+  void InitP4Info(::p4::config::v1::P4Info* p4info) {
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+    EXPECT_TRUE(status.ok())
+        << "ParseProtoFromString: " << status;
+  }
+};
+
+/**
+ * Exercises client.connect() error path.
+ */
+TEST_F(DoConfigTunnelSrcPortTest, connectFailure) {
+  struct src_port_info port_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::InternalError("connect")));
+
+  auto status =
+      DoConfigTunnelSrcPortEntry(client, port_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "connect")
+      << status;
+}
+
+/**
+ * Exercises config.getPipelineConfig() error path.
+ */
+TEST_F(DoConfigTunnelSrcPortTest, getPipelineConfigFailure) {
+  struct src_port_info port_info = {0};
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError("getPipelineConfig")));
+
+  auto status =
+      DoConfigTunnelSrcPortEntry(client, port_info, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == "getPipelineConfig")
+      << status;
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_vlan_entry_test.cc
@@ -1,0 +1,80 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal test for DoConfigVlanEntry().
+
+#include <absl/status/status.h>
+#include <stdint.h>
+
+// clang-format off
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+// clang-format on
+
+#include "client/ovsp4rt_test_client_mock.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_doconfig_int.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace ovsp4rt {
+
+constexpr bool INSERT_ENTRY = true;
+constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
+constexpr uint16_t VLAN_ID = 0x1984;
+
+class DoConfigVlanEntryTest : public ::testing::Test {
+ protected:
+  DoConfigVlanEntryTest() {}
+  virtual ~DoConfigVlanEntryTest() = default;
+
+  void InitP4Info(::p4::config::v1::P4Info* p4info) {
+    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+    EXPECT_TRUE(status.ok())
+        << "ParseProtoFromString: " << status;
+  }
+};
+
+/**
+ * Exercises client.connect() error path.
+ */
+TEST_F(DoConfigVlanEntryTest, connectFailure) {
+  constexpr char CONNECT_ERROR[] = "connect";
+  constexpr uint16_t vlan_id = VLAN_ID;
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect)
+      .WillOnce(Return(absl::InternalError(CONNECT_ERROR)));
+
+  auto status = DoConfigVlanEntry(client, vlan_id, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == CONNECT_ERROR)
+      << status.message();
+}
+
+/**
+ * Exercises config.getPipelineConfig() error path.
+ */
+TEST_F(DoConfigVlanEntryTest, getPipelineConfigFailure) {
+  constexpr char PIPELINE_ERROR[] = "getPipelineConfig";
+  constexpr uint16_t vlan_id = VLAN_ID;
+
+  TestClientMock client;
+  EXPECT_CALL(client, connect).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(client, getPipelineConfig)
+      .WillOnce(Return(absl::InternalError(PIPELINE_ERROR)));
+
+  auto status = DoConfigVlanEntry(client, vlan_id, INSERT_ENTRY, GRPC_ADDR);
+
+  ASSERT_FALSE(status.ok());
+  ASSERT_TRUE(IsInternal(status) && status.message() == PIPELINE_ERROR)
+      << status.message();
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/do_config_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/do_config_vlan_entry_test.cc
@@ -35,8 +35,7 @@ class DoConfigVlanEntryTest : public ::testing::Test {
 
   void InitP4Info(::p4::config::v1::P4Info* p4info) {
     auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status;
+    EXPECT_TRUE(status.ok()) << "ParseProtoFromString: " << status;
   }
 };
 


### PR DESCRIPTION
- Extracted `ConfigFdbEntry`.
- Extracted `ConfigIpMacMapEntry`.
- Extracted `ConfigSrcPortEntry`.
- Extracted `ConfigTunnelEntry`.
- Extracted `ConfigTunnelSrcPortEntry`.
- Extracted `ConfigVlanEntry`.

- Defined a minimal unit test for each DoConfigEntry function.