### PR TITLE
Rename ovsp4rt functions (draft)

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -1561,7 +1561,7 @@ void EncodeV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 #endif  // ES2K_TARGET
 
 #if defined(ES2K_TARGET)
-// called-by: ConfigEncapTableEntry
+// called-by: WriteEncapTableEntry
 void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
                                 const struct tunnel_info& tunnel_info,
                                 const ::p4::config::v1::P4Info& p4info,
@@ -1587,10 +1587,10 @@ void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
 #endif  // ES2K_TARGET
 
 // called-by: DoConfigTunnelEntry (common)
-absl::Status ConfigEncapTableEntry(ClientInterface& client,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+absl::Status WriteEncapTableEntry(ClientInterface& client,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -2691,7 +2691,7 @@ absl::Status ConfigTunnelEntry(ClientInterface& client,
                                bool insert_entry) {
   absl::Status status;
 
-  status = ConfigEncapTableEntry(client, tunnel_info, p4info, insert_entry);
+  status = WriteEncapTableEntry(client, tunnel_info, p4info, insert_entry);
   if (!status.ok()) return status;
 
 #if defined(ES2K_TARGET)

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -2049,7 +2049,7 @@ void EncodeTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
 #endif
 }
 
-absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
+absl::StatusOr<::p4::v1::ReadResponse> ReadL2ToTunnelV4TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
@@ -2063,7 +2063,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
   return client.sendReadRequest(read_request);
 }
 
-absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
+absl::StatusOr<::p4::v1::ReadResponse> ReadL2ToTunnelV6TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
@@ -2077,7 +2077,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// extracted from GetFdbTunnelTableEntry
+// extracted from ReadFdbTunnelTableEntry
 void PrepareFdbTableV4TunnelEntry(p4::v1::TableEntry* table_entry,
                                   const struct mac_learning_info& learn_info,
                                   const ::p4::config::v1::P4Info& p4info,
@@ -2098,7 +2098,7 @@ void PrepareFdbTableV4TunnelEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
+absl::StatusOr<::p4::v1::ReadResponse> ReadFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding) {
   ::p4::v1::ReadRequest read_request;
@@ -2119,7 +2119,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
   return client.sendReadRequest(read_request);
 }
 
-absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
+absl::StatusOr<::p4::v1::ReadResponse> ReadFdbVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding) {
   ::p4::v1::ReadRequest read_request;
@@ -2134,7 +2134,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
 }
 
 // called-by: DoConfigIpMacMapEntry (es2k)
-absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
+absl::StatusOr<::p4::v1::ReadResponse> ReadVmSrcTableEntry(
     ClientInterface& client, struct ip_mac_map_info ip_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
@@ -2149,7 +2149,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
 }
 
 // called-by: DoConfigIpMacMapEntry (es2k)
-absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
+absl::StatusOr<::p4::v1::ReadResponse> ReadVmDstTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
@@ -2164,7 +2164,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
 }
 
 // called-by: DoConfigSrcPortEntry, ConfigFdbUpdateSrcPort
-absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
+absl::StatusOr<::p4::v1::ReadResponse> ReadTxAccVsiTableEntry(
     ClientInterface& client, uint32_t sp,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
@@ -2314,7 +2314,7 @@ void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
                                const ::p4::config::v1::P4Info& p4info) {
   // Matching entry in IPv4 tunnel table?
   auto status_or_read_response =
-      GetL2ToTunnelV4TableEntry(client, learn_info, p4info);
+      ReadL2ToTunnelV4TableEntry(client, learn_info, p4info);
   if (status_or_read_response.ok()) {
     // Yes, we're deleting an IPv4 tunnel.
     learn_info.is_tunnel = true;
@@ -2323,7 +2323,7 @@ void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
   if (!learn_info.is_tunnel) {
     // Matching entry in IPv6 tunnel table?
     status_or_read_response =
-        GetL2ToTunnelV6TableEntry(client, learn_info, p4info);
+        ReadL2ToTunnelV6TableEntry(client, learn_info, p4info);
     if (status_or_read_response.ok()) {
       // We're deleting an IPv6 tunnel.
       learn_info.is_tunnel = true;
@@ -2338,7 +2338,7 @@ absl::Status ConfigFdbUpdateSrcPort(ClientInterface& client,
                                     struct mac_learning_info& learn_info,
                                     const ::p4::config::v1::P4Info& p4info) {
   auto response_or_status =
-      GetTxAccVsiTableEntry(client, learn_info.src_port, p4info);
+      ReadTxAccVsiTableEntry(client, learn_info.src_port, p4info);
   if (!response_or_status.ok()) {
     return response_or_status.status();
   }
@@ -2377,7 +2377,7 @@ absl::Status ConfigFdbTunnelEntry(ClientInterface& client,
                                   const ::p4::config::v1::P4Info& p4info) {
   if (insert_entry) {
     auto status_or_read_response =
-        GetFdbTunnelTableEntry(client, learn_info, p4info, true);
+        ReadFdbTunnelTableEntry(client, learn_info, p4info, true);
     if (status_or_read_response.ok()) {
       // Return if entry already exists.
       return absl::OkStatus();
@@ -2405,7 +2405,7 @@ absl::Status ConfigFdbVlanEntry(ClientInterface& client,
 
   if (insert_entry) {
     auto status_or_read_response =
-        GetFdbVlanTableEntry(client, learn_info, p4info, true);
+        ReadFdbVlanTableEntry(client, learn_info, p4info, true);
     if (status_or_read_response.ok()) {
       // Return if entry already exists.
       return absl::OkStatus();
@@ -2549,7 +2549,7 @@ absl::Status ConfigSrcPortEntry(ClientInterface& client,
                                 bool insert_entry) {
   // TODO(derek): refactor (extract method)
   auto response_or_status =
-      GetTxAccVsiTableEntry(client, vsi_sp.src_port, p4info);
+      ReadTxAccVsiTableEntry(client, vsi_sp.src_port, p4info);
   if (!response_or_status.ok()) return response_or_status.status();
 
   ::p4::v1::ReadResponse read_response = std::move(response_or_status).value();
@@ -2732,7 +2732,7 @@ absl::Status ConfigIpMacMapEntry(ClientInterface& client,
                                  const ::p4::config::v1::P4Info& p4info,
                                  bool insert_entry) {
   if (insert_entry) {
-    auto status_or_read_response = GetVmSrcTableEntry(client, ip_info, p4info);
+    auto status_or_read_response = ReadVmSrcTableEntry(client, ip_info, p4info);
     if (status_or_read_response.ok()) {
       goto try_dstip;
     }
@@ -2745,7 +2745,7 @@ absl::Status ConfigIpMacMapEntry(ClientInterface& client,
 
 try_dstip:
   if (insert_entry) {
-    auto status_or_read_response = GetVmDstTableEntry(client, ip_info, p4info);
+    auto status_or_read_response = ReadVmDstTableEntry(client, ip_info, p4info);
     if (status_or_read_response.ok()) {
       return status_or_read_response.status();
     }

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -128,10 +128,10 @@ static inline int32_t ValidIpAddr(uint32_t nw_addr) {
 }
 
 #if defined(ES2K_TARGET)
-void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct mac_learning_info& learn_info,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry, DiagDetail& detail) {
+void EncodeFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
+                             const struct mac_learning_info& learn_info,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_SMAC_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_SMAC_TABLE));
 
@@ -155,10 +155,10 @@ void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_TX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
@@ -242,10 +242,10 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 
-void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_RX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_TABLE));
 
@@ -280,10 +280,10 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
 
 #elif defined(DPDK_TARGET)
 
-void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_RX_WITH_TUNNEL_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE));
 
@@ -315,7 +315,7 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
 #error "ASSERT: Unknown TARGET type!"
 #endif
 
-void PrepareFdbTableEntryforV4VxlanTunnel(
+void EncodeFdbTableEntryforV4VxlanTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
@@ -421,7 +421,7 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
 #ifdef ES2K_TARGET
 
 // Never called when DPDK_TARGET is enabled.
-void PrepareFdbTableEntryforV4GeneveTunnel(
+void EncodeFdbTableEntryforV4GeneveTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
@@ -524,10 +524,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
 #endif
 }
 
-void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
-                         const struct mac_learning_info& learn_info,
-                         const ::p4::config::v1::P4Info& p4info,
-                         bool insert_entry, DiagDetail& detail) {
+void EncodeL2ToTunnelV4(p4::v1::TableEntry* table_entry,
+                        const struct mac_learning_info& learn_info,
+                        const ::p4::config::v1::P4Info& p4info,
+                        bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_TO_TUNNEL_V4_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V4_TABLE));
 
@@ -554,10 +554,10 @@ void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
-                         const struct mac_learning_info& learn_info,
-                         const ::p4::config::v1::P4Info& p4info,
-                         bool insert_entry, DiagDetail& detail) {
+void EncodeL2ToTunnelV6(p4::v1::TableEntry* table_entry,
+                        const struct mac_learning_info& learn_info,
+                        const ::p4::config::v1::P4Info& p4info,
+                        bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_TO_TUNNEL_V6_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V6_TABLE));
 
@@ -594,8 +594,8 @@ absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareFdbSmacTableEntry(table_entry, learn_info, p4info, insert_entry,
-                           detail);
+  EncodeFdbSmacTableEntry(table_entry, learn_info, p4info, insert_entry,
+                          detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -612,9 +612,9 @@ void PrepareL2TunnelTableEntry(p4::v1::TableEntry* table_entry,
                                bool insert_entry, DiagDetail& detail) {
   if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
       learn_info.tnl_info.remote_ip.family == AF_INET6) {
-    PrepareL2ToTunnelV6(table_entry, learn_info, p4info, insert_entry, detail);
+    EncodeL2ToTunnelV6(table_entry, learn_info, p4info, insert_entry, detail);
   } else {
-    PrepareL2ToTunnelV4(table_entry, learn_info, p4info, insert_entry, detail);
+    EncodeL2ToTunnelV4(table_entry, learn_info, p4info, insert_entry, detail);
   }
 }
 
@@ -650,8 +650,8 @@ absl::Status ConfigFdbTxVlanTableEntry(
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
-                             detail);
+  EncodeFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
+                            detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -671,8 +671,8 @@ absl::Status ConfigFdbRxVlanTableEntry(
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
-                             detail);
+  EncodeFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
+                            detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -689,17 +689,17 @@ void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
                                     const ::p4::config::v1::P4Info& p4info,
                                     bool insert_entry, DiagDetail& detail) {
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                         insert_entry, detail);
+    EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                        insert_entry, detail);
   } else if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
-                                          insert_entry, detail);
+    EncodeFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
+                                         insert_entry, detail);
   } else {
     if (!insert_entry) {
       // Tunnel type doesn't matter for delete. So calling one of the functions
       // to prepare the entry
-      PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                           insert_entry, detail);
+      EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                          insert_entry, detail);
     }
   }
 }
@@ -715,8 +715,8 @@ absl::Status ConfigFdbTunnelTableEntry(
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
 #if defined(DPDK_TARGET)
-  PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                       insert_entry, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                      insert_entry, detail);
 #elif defined(ES2K_TARGET)
   Es2kPrepareFdbTunnelTableEntry(table_entry, learn_info, p4info, insert_entry,
                                  detail);
@@ -734,10 +734,10 @@ absl::Status ConfigFdbTunnelTableEntry(
 
 /* VXLAN_ENCAP_MOD_TABLE */
 // Ipv4, Tagged, Vxlan
-void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -797,10 +797,10 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 #if defined(ES2K_TARGET)
 /* GENEVE_ENCAP_MOD_TABLE */
 // Ipv4, Tagged, Geneve
-void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct tunnel_info& tunnel_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry) {
+void EncodeGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct tunnel_info& tunnel_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -862,13 +862,12 @@ void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
                             const ::p4::config::v1::P4Info& p4info,
                             bool insert_entry) {
 #if defined(DPDK_TARGET)
-  PrepareVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveEncapTableEntry(table_entry, tunnel_info, p4info,
-                                 insert_entry);
+    EncodeGeneveEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -879,10 +878,10 @@ void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 /* VXLAN_ENCAP_V6_MOD_TABLE */
 // Ipv6, Tagged, Vxlan
-void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+void EncodeV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_V6_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -939,10 +938,10 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 /* GENEVE_ENCAP_V6_MOD_TABLE */
 // Ipv6, Tagged, Geneve
-void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct tunnel_info& tunnel_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry) {
+void EncodeV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_V6_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -1003,18 +1002,18 @@ void PrepareV6EncapTableEntry(p4::v1::TableEntry* table_entry,
                               const ::p4::config::v1::P4Info& p4info,
                               bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareV6VxlanEncapTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+    EncodeV6VxlanEncapTableEntry(table_entry, tunnel_info, p4info,
+                                 insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareV6GeneveEncapTableEntry(table_entry, tunnel_info, p4info,
-                                   insert_entry);
+    EncodeV6GeneveEncapTableEntry(table_entry, tunnel_info, p4info,
+                                  insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
 }
 
 /* VXLAN_ENCAP_VLAN_POP_MOD_TABLE */
-void PrepareVxlanEncapAndVlanPopTableEntry(
+void EncodeVxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE));
@@ -1076,7 +1075,7 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
 }
 
 /* GENEVE_ENCAP_VLAN_POP_MOD_TABLE */
-void PrepareGeneveEncapAndVlanPopTableEntry(
+void EncodeGeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1144,11 +1143,11 @@ void PrepareEncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
                                       const ::p4::config::v1::P4Info& p4info,
                                       bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                          insert_entry);
+    EncodeVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                         insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                           insert_entry);
+    EncodeGeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                          insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -1156,7 +1155,7 @@ void PrepareEncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
 
 /* VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE */
 // Ipv6, Untagged, Vxlan
-void PrepareV6VxlanEncapAndVlanPopTableEntry(
+void EncodeV6VxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1220,7 +1219,7 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
 
 /* GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE */
 // Ipv6, Untagged, Geneve
-void PrepareV6GeneveEncapAndVlanPopTableEntry(
+void EncodeV6GeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1289,20 +1288,20 @@ void PrepareV6EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
                                         const ::p4::config::v1::P4Info& p4info,
                                         bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareV6VxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                            insert_entry);
+    EncodeV6VxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                           insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareV6GeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                             insert_entry);
+    EncodeV6GeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                            insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
 }
 
-void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                               const struct tunnel_info& tunnel_info,
-                               const ::p4::config::v1::P4Info& p4info,
-                               bool insert_entry) {
+void EncodeRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE));
 
@@ -1335,10 +1334,10 @@ void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE));
 
@@ -1373,10 +1372,10 @@ void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
 
 #endif  // ES2K_TARGET
 
-void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   // match remote ipv4 addr
   auto match1 = table_entry->add_match();
   match1->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
@@ -1486,10 +1485,10 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 #if defined(ES2K_TARGET)
-void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+void EncodeV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, IPV6_TUNNEL_TERM_TABLE));
 
   // TODO(derek): table does not have a bridge_id match field. [es2k]
@@ -1609,10 +1608,10 @@ absl::Status ConfigEncapTableEntry(ClientInterface& client,
 
 #if defined(ES2K_TARGET)
 
-void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct tunnel_info& tunnel_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry) {
+void EncodeVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_DECAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
@@ -1628,10 +1627,10 @@ void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct tunnel_info& tunnel_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+void EncodeGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
+                                    const struct tunnel_info& tunnel_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_DECAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
@@ -1654,18 +1653,18 @@ void PrepareDecapModTableEntry(p4::v1::TableEntry* table_entry,
                                const ::p4::config::v1::P4Info& p4info,
                                bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanDecapModTableEntry(table_entry, tunnel_info, p4info,
-                                   insert_entry);
+    EncodeVxlanDecapModTableEntry(table_entry, tunnel_info, p4info,
+                                  insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveDecapModTableEntry(table_entry, tunnel_info, p4info,
-                                    insert_entry);
+    EncodeGeneveDecapModTableEntry(table_entry, tunnel_info, p4info,
+                                   insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
 }
 
 // called-by: PrepareDecapModAndVlanPushTableEntry
-void PrepareVxlanDecapModAndVlanPushTableEntry(
+void EncodeVxlanDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1710,7 +1709,7 @@ void PrepareVxlanDecapModAndVlanPushTableEntry(
 }
 
 // called-by: PrepareDecapModAndVlanPushTableEntry
-void PrepareGeneveDecapModAndVlanPushTableEntry(
+void EncodeGeneveDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1760,11 +1759,11 @@ void PrepareDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
-                                              insert_entry);
+    EncodeVxlanDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
+                                             insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
-                                               insert_entry);
+    EncodeGeneveDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
+                                              insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -1798,10 +1797,10 @@ absl::Status ConfigDecapTableEntry(ClientInterface& client,
   return client.sendWriteRequest(write_request);
 }
 
-void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
-                               const uint16_t vlan_id,
-                               const ::p4::config::v1::P4Info& p4info,
-                               bool insert_entry) {
+void EncodeVlanPushTableEntry(p4::v1::TableEntry* table_entry,
+                              const uint16_t vlan_id,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_PUSH_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VLAN_PUSH_MOD_TABLE,
@@ -1839,10 +1838,10 @@ void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
-                              const uint16_t vlan_id,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry) {
+void EncodeVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                             const uint16_t vlan_id,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_POP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VLAN_POP_MOD_TABLE,
@@ -1868,7 +1867,7 @@ absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareVlanPushTableEntry(table_entry, vlan_id, p4info, insert_entry);
+  EncodeVlanPushTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -1883,16 +1882,16 @@ absl::Status ConfigVlanPopTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareVlanPopTableEntry(table_entry, vlan_id, p4info, insert_entry);
+  EncodeVlanPopTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
 
 // called-by: DoConfigTunnelSrcPortEntry (es2k)
-void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct src_port_info& sp,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry) {
+void EncodeSrcPortTableEntry(p4::v1::TableEntry* table_entry,
+                             const struct src_port_info& sp,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE));
 
@@ -1929,10 +1928,10 @@ void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct ip_mac_map_info& ip_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry, DiagDetail& detail) {
+void EncodeSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct ip_mac_map_info& ip_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_SRC_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, SRC_IP_MAC_MAP_TABLE));
 
@@ -1978,10 +1977,10 @@ void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct ip_mac_map_info& ip_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry, DiagDetail& detail) {
+void EncodeDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct ip_mac_map_info& ip_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_DST_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, DST_IP_MAC_MAP_TABLE));
 
@@ -2027,8 +2026,8 @@ void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
-                               const ::p4::config::v1::P4Info& p4info) {
+void EncodeTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
+                              const ::p4::config::v1::P4Info& p4info) {
   table_entry->set_table_id(GetTableId(p4info, TX_ACC_VSI_TABLE));
 
   auto match = table_entry->add_match();
@@ -2058,7 +2057,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareL2ToTunnelV4(table_entry, learn_info, p4info, false, detail);
+  EncodeL2ToTunnelV4(table_entry, learn_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -2072,7 +2071,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareL2ToTunnelV6(table_entry, learn_info, p4info, false, detail);
+  EncodeL2ToTunnelV6(table_entry, learn_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -2090,11 +2089,11 @@ void PrepareFdbTableV4TunnelEntry(p4::v1::TableEntry* table_entry,
   // The optional 'testing' parameter (which defaults to 'false') allows
   // the unit test to override this behavior.
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                         testing, detail);
+    EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                        testing, detail);
   } else if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
-                                          testing, detail);
+    EncodeFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
+                                         testing, detail);
   }
 }
 
@@ -2108,8 +2107,8 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
   table_entry = client.initReadRequest(&read_request);
 
 #if defined(DPDK_TARGET)
-  PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
-                                       detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
+                                      detail);
 #elif defined(ES2K_TARGET)
   PrepareFdbTableV4TunnelEntry(table_entry, learn_info, p4info, false, detail);
 #else
@@ -2128,7 +2127,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, false, detail);
+  EncodeFdbTxVlanTableEntry(table_entry, learn_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -2143,7 +2142,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
+  EncodeSrcIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -2158,7 +2157,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
+  EncodeDstIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -2172,7 +2171,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareTxAccVsiTableEntry(table_entry, sp, p4info);
+  EncodeTxAccVsiTableEntry(table_entry, sp, p4info);
 
   return client.sendReadRequest(read_request);
 }
@@ -2187,7 +2186,7 @@ absl::Status ConfigVsiSrcPortTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareSrcPortTableEntry(table_entry, sp, p4info, insert_entry);
+  EncodeSrcPortTableEntry(table_entry, sp, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -2199,10 +2198,10 @@ void PrepareRxTunnelSrcPortTableEntry(p4::v1::TableEntry* table_entry,
                                       bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-    PrepareRxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeRxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-    PrepareV6RxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeV6RxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   }
 }
 
@@ -2228,11 +2227,11 @@ void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                      bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-    PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-    PrepareV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+    EncodeV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
+                                 insert_entry);
   }
 }
 
@@ -2249,7 +2248,7 @@ absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
 #if defined(DPDK_TARGET)
-  PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
   Es2kPrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info,
                                   insert_entry);
@@ -2273,8 +2272,8 @@ absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
-                               detail);
+  EncodeDstIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
+                              detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -2294,8 +2293,8 @@ absl::Status ConfigSrcIpMacMapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
-                               detail);
+  EncodeSrcIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
+                              detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -2511,7 +2510,7 @@ absl::Status ConfigTunnelSrcPortEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
+  EncodeSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -584,10 +584,10 @@ void EncodeL2ToTunnelV6(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
-                                     const struct mac_learning_info& learn_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+absl::Status WriteFdbSmacTableEntry(ClientInterface& client,
+                                    const struct mac_learning_info& learn_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -605,7 +605,7 @@ absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
   return status;
 }
 
-// extracted from ConfigL2TunnelTableEntry
+// extracted from WriteL2TunnelTableEntry
 void PrepareL2TunnelTableEntry(p4::v1::TableEntry* table_entry,
                                const struct mac_learning_info& learn_info,
                                const ::p4::config::v1::P4Info& p4info,
@@ -618,9 +618,10 @@ void PrepareL2TunnelTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::Status ConfigL2TunnelTableEntry(
-    ClientInterface& client, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
+absl::Status WriteL2TunnelTableEntry(ClientInterface& client,
+                                     const struct mac_learning_info& learn_info,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -641,7 +642,7 @@ absl::Status ConfigL2TunnelTableEntry(
 #endif  // ES2K_TARGET
 
 // called-by: ConfigFdbVlanEntry (dpdk, es2k)
-absl::Status ConfigFdbTxVlanTableEntry(
+absl::Status WriteFdbTxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -662,7 +663,7 @@ absl::Status ConfigFdbTxVlanTableEntry(
 }
 
 // called-by: ConfigFdbVlanEntry (dpdk, es2k)
-absl::Status ConfigFdbRxVlanTableEntry(
+absl::Status WriteFdbRxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -683,7 +684,7 @@ absl::Status ConfigFdbRxVlanTableEntry(
 }
 
 #if defined(ES2K_TARGET)
-// extracted from ConfigFdbTunnelTableEntry
+// extracted from WriteFdbTunnelTableEntry
 void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
                                     const struct mac_learning_info& learn_info,
                                     const ::p4::config::v1::P4Info& p4info,
@@ -705,7 +706,7 @@ void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-absl::Status ConfigFdbTunnelTableEntry(
+absl::Status WriteFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -1769,7 +1770,7 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
-// called-by: ConfigDecapTableEntry
+// called-by: WriteDecapTableEntry
 void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
                                 const struct tunnel_info& tunnel_info,
                                 const ::p4::config::v1::P4Info& p4info,
@@ -1783,10 +1784,10 @@ void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
 }
 
 // called-by: DoConfigTunnelEntry (es2k)
-absl::Status ConfigDecapTableEntry(ClientInterface& client,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+absl::Status WriteDecapTableEntry(ClientInterface& client,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -1858,10 +1859,10 @@ void EncodeVlanPopTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 // called-by: DoConfigVlanEntry (es2k)
-absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
-                                      const uint16_t vlan_id,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+absl::Status WriteVlanPushTableEntry(ClientInterface& client,
+                                     const uint16_t vlan_id,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -1873,10 +1874,10 @@ absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
 }
 
 // called-by: DoConfigVlanEntry (es2k)
-absl::Status ConfigVlanPopTableEntry(ClientInterface& client,
-                                     const uint16_t vlan_id,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+absl::Status WriteVlanPopTableEntry(ClientInterface& client,
+                                    const uint16_t vlan_id,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -2177,10 +2178,10 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
 }
 
 // called-by: DoConfigSrcPortEntry (es2k)
-absl::Status ConfigVsiSrcPortTableEntry(ClientInterface& client,
-                                        const struct src_port_info& sp,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry) {
+absl::Status WriteVsiSrcPortTableEntry(ClientInterface& client,
+                                       const struct src_port_info& sp,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -2191,7 +2192,7 @@ absl::Status ConfigVsiSrcPortTableEntry(ClientInterface& client,
   return client.sendWriteRequest(write_request);
 }
 
-// extracted from ConfigRxTunnelSrcPortTableEntry
+// extracted from WriteRxTunnelSrcPortTableEntry
 void PrepareRxTunnelSrcPortTableEntry(p4::v1::TableEntry* table_entry,
                                       const struct tunnel_info& tunnel_info,
                                       const ::p4::config::v1::P4Info& p4info,
@@ -2206,7 +2207,7 @@ void PrepareRxTunnelSrcPortTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 // called-by: DoConfigRxTunnelSrcEntry (es2k)
-absl::Status ConfigRxTunnelSrcPortTableEntry(
+absl::Status WriteRxTunnelSrcPortTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -2220,7 +2221,7 @@ absl::Status ConfigRxTunnelSrcPortTableEntry(
   return client.sendWriteRequest(write_request);
 }
 
-// called-by: ConfigTunnelTermTableEntry
+// called-by: WriteTunnelTermTableEntry
 void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                      const struct tunnel_info& tunnel_info,
                                      const ::p4::config::v1::P4Info& p4info,
@@ -2238,10 +2239,10 @@ void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 #endif  // ES2K_TARGET
 
 // called-by: DoConfigTunnelEntry (common)
-absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry) {
+absl::Status WriteTunnelTermTableEntry(ClientInterface& client,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -2262,10 +2263,10 @@ absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
 #if defined(ES2K_TARGET)
 
 // called-by: DoConfigIpMacMapEntry (es2k)
-absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry) {
+absl::Status WriteDstIpMacMapTableEntry(ClientInterface& client,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -2283,10 +2284,10 @@ absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
 }
 
 // called-by: DoConfigIpMacMapEntry (es2k)
-absl::Status ConfigSrcIpMacMapTableEntry(ClientInterface& client,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry) {
+absl::Status WriteSrcIpMacMapTableEntry(ClientInterface& client,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -2384,13 +2385,13 @@ absl::Status ConfigFdbTunnelEntry(ClientInterface& client,
   }
 
   // Ignores status (why?)
-  (void)ConfigFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
 
   // Ignores status (why?)
-  (void)ConfigL2TunnelTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteL2TunnelTableEntry(client, learn_info, p4info, insert_entry);
 
   // Ignores status (why?)
-  (void)ConfigFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
 
   return absl::OkStatus();
 }
@@ -2411,17 +2412,17 @@ absl::Status ConfigFdbVlanEntry(ClientInterface& client,
     }
 
     // Ignores status (why?)
-    (void)ConfigFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
+    (void)WriteFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
 
     status = ConfigFdbUpdateSrcPort(client, learn_info, p4info);
     if (!status.ok()) return status;
   }
 
   // Ignores status (why?)
-  (void)ConfigFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
 
   // Ignores status (why?)
-  (void)ConfigFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
 
   return absl::OkStatus();
 }
@@ -2492,8 +2493,8 @@ absl::Status DoConfigRxTunnelSrcEntry(ClientInterface& client,
   if (!status.ok()) return status;
 
   // Update P4 tables.
-  return ConfigRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
-                                         insert_entry);
+  return WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
+                                        insert_entry);
 }
 
 //----------------------------------------------------------------------
@@ -2501,10 +2502,10 @@ absl::Status DoConfigRxTunnelSrcEntry(ClientInterface& client,
 //----------------------------------------------------------------------
 
 // extracted from DoConfigTunnelSrcPortEntry (testable)
-absl::Status ConfigTunnelSrcPortEntry(ClientInterface& client,
-                                      const struct src_port_info& tnl_sp,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+absl::Status WriteTunnelSrcPortEntry(ClientInterface& client,
+                                     const struct src_port_info& tnl_sp,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -2531,7 +2532,7 @@ absl::Status DoConfigTunnelSrcPortEntry(ClientInterface& client,
   if (!status.ok()) return status;
 
   // Update P4 tables.
-  return ConfigTunnelSrcPortEntry(client, tnl_sp, p4info, insert_entry);
+  return WriteTunnelSrcPortEntry(client, tnl_sp, p4info, insert_entry);
 }
 
 //----------------------------------------------------------------------
@@ -2580,7 +2581,7 @@ absl::Status ConfigSrcPortEntry(ClientInterface& client,
   vsi_sp.src_port = host_sp;
   // end of refactoring
 
-  return ConfigVsiSrcPortTableEntry(client, vsi_sp, p4info, insert_entry);
+  return WriteVsiSrcPortTableEntry(client, vsi_sp, p4info, insert_entry);
 }
 
 absl::Status DoConfigSrcPortEntry(ClientInterface& client,
@@ -2611,10 +2612,10 @@ absl::Status ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
                              bool insert_entry) {
   absl::Status status;
 
-  status = ConfigVlanPushTableEntry(client, vlan_id, p4info, insert_entry);
+  status = WriteVlanPushTableEntry(client, vlan_id, p4info, insert_entry);
   if (!status.ok()) return status;
 
-  return ConfigVlanPopTableEntry(client, vlan_id, p4info, insert_entry);
+  return WriteVlanPopTableEntry(client, vlan_id, p4info, insert_entry);
 }
 
 absl::Status DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
@@ -2646,13 +2647,13 @@ absl::Status ConfigFdbEntry(ClientInterface& client,
                             const ::p4::config::v1::P4Info& p4info,
                             bool insert_entry) {
   if (learn_info.is_tunnel) {
-    return ConfigFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
+    return WriteFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
   } else if (learn_info.is_vlan) {
     auto status =
-        ConfigFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
+        WriteFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
     if (!status.ok()) return status;
 
-    return ConfigFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
+    return WriteFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
   } else {
     // TODO(Derek): return error status?
     return absl::OkStatus();
@@ -2694,11 +2695,11 @@ absl::Status ConfigTunnelEntry(ClientInterface& client,
   if (!status.ok()) return status;
 
 #if defined(ES2K_TARGET)
-  status = ConfigDecapTableEntry(client, tunnel_info, p4info, insert_entry);
+  status = WriteDecapTableEntry(client, tunnel_info, p4info, insert_entry);
   if (!status.ok()) return status;
 #endif
 
-  return ConfigTunnelTermTableEntry(client, tunnel_info, p4info, insert_entry);
+  return WriteTunnelTermTableEntry(client, tunnel_info, p4info, insert_entry);
 }
 
 absl::Status DoConfigTunnelEntry(ClientInterface& client,
@@ -2739,7 +2740,7 @@ absl::Status ConfigIpMacMapEntry(ClientInterface& client,
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
     // Ignores errors (why?)
-    (void)ConfigSrcIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
+    (void)WriteSrcIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
   }
 
 try_dstip:
@@ -2752,7 +2753,7 @@ try_dstip:
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
     // Ignores errors (why?)
-    (void)ConfigDstIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
+    (void)WriteDstIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
   }
   return absl::OkStatus();
 }

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -46,9 +46,10 @@ extern absl::Status WriteDstIpMacMapTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigEncapTableEntry(
-    ClientInterface& client, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern absl::Status WriteEncapTableEntry(ClientInterface& client,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
 
 extern absl::Status WriteFdbSmacTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -15,33 +15,34 @@
 
 namespace ovsp4rt {
 
-extern absl::Status ConfigFdbRxVlanTableEntry(
+extern absl::Status WriteFdbRxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-absl::Status ConfigFdbTunnelTableEntry(
+absl::Status WriteFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigFdbTxVlanTableEntry(
+extern absl::Status WriteFdbTxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigL2TunnelTableEntry(
+extern absl::Status WriteL2TunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigTunnelTermTableEntry(
+extern absl::Status WriteTunnelTermTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
 #if defined(ES2K_TARGET)
 
-extern absl::Status ConfigDecapTableEntry(
-    ClientInterface& client, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern absl::Status WriteDecapTableEntry(ClientInterface& client,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
 
-extern absl::Status ConfigDstIpMacMapTableEntry(
+extern absl::Status WriteDstIpMacMapTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
@@ -49,7 +50,7 @@ extern absl::Status ConfigEncapTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigFdbSmacTableEntry(
+extern absl::Status WriteFdbSmacTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
@@ -61,23 +62,23 @@ extern void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
                                       struct mac_learning_info& learn_info,
                                       const ::p4::config::v1::P4Info& p4info);
 
-extern absl::Status ConfigRxTunnelSrcPortTableEntry(
+extern absl::Status WriteRxTunnelSrcPortTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigSrcIpMacMapTableEntry(
+extern absl::Status WriteSrcIpMacMapTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigVlanPopTableEntry(
+extern absl::Status WriteVlanPopTableEntry(
     ClientInterface& client, const uint16_t vlan_id,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigVlanPushTableEntry(
+extern absl::Status WriteVlanPushTableEntry(
     ClientInterface& client, const uint16_t vlan_id,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigVsiSrcPortTableEntry(
+extern absl::Status WriteVsiSrcPortTableEntry(
     ClientInterface& client, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -82,27 +82,27 @@ extern absl::Status WriteVsiSrcPortTableEntry(
     ClientInterface& client, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
+extern absl::StatusOr<::p4::v1::ReadResponse> ReadFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false);
 
-extern absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
+extern absl::StatusOr<::p4::v1::ReadResponse> ReadFdbVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false);
 
-extern absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
+extern absl::StatusOr<::p4::v1::ReadResponse> ReadL2ToTunnelV4TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info);
 
-extern absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
+extern absl::StatusOr<::p4::v1::ReadResponse> ReadL2ToTunnelV6TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info);
 
-extern absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
+extern absl::StatusOr<::p4::v1::ReadResponse> ReadVmDstTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info);
 
-extern absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
+extern absl::StatusOr<::p4::v1::ReadResponse> ReadVmSrcTableEntry(
     ClientInterface& client, struct ip_mac_map_info ip_info,
     const ::p4::config::v1::P4Info& p4info);
 

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -38,7 +38,7 @@ extern void EncodeFdbTxVlanTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-// extracted from ConfigL2TunnelTableEntry
+// extracted from WriteL2TunnelTableEntry
 extern void PrepareL2TunnelTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -18,22 +18,22 @@ namespace ovsp4rt {
 // Common functions
 //----------------------------------------------------------------------
 
-extern void PrepareFdbRxVlanTableEntry(
+extern void EncodeFdbRxVlanTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareFdbTableEntryforV4GeneveTunnel(
+extern void EncodeFdbTableEntryforV4GeneveTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareFdbTableEntryforV4VxlanTunnel(
+extern void EncodeFdbTableEntryforV4VxlanTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareFdbTxVlanTableEntry(
+extern void EncodeFdbTxVlanTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
@@ -44,15 +44,15 @@ extern void PrepareL2TunnelTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry);
+extern void EncodeVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
 
-extern void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry);
+extern void EncodeTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
 
 //----------------------------------------------------------------------
 // ES2K-specific functions
@@ -84,53 +84,53 @@ extern void Es2kPrepareTunnelTermTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry, DiagDetail& detail);
+extern void EncodeDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry, DiagDetail& detail);
 
-extern void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct mac_learning_info& learn_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry, DiagDetail& detail);
+extern void EncodeFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
+                                    const struct mac_learning_info& learn_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry, DiagDetail& detail);
 
-extern void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry, DiagDetail& detail);
+extern void EncodeSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry, DiagDetail& detail);
 
-extern void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail);
+extern void EncodeL2ToTunnelV4(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail);
 
-extern void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail);
+extern void EncodeL2ToTunnelV6(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail);
 
-extern void PrepareGeneveDecapModTableEntry(
+extern void EncodeGeneveDecapModTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareGeneveDecapModAndVlanPushTableEntry(
+extern void EncodeGeneveDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                         const struct tunnel_info& tunnel_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry);
+extern void EncodeGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry);
 
-extern void PrepareGeneveEncapAndVlanPopTableEntry(
+extern void EncodeGeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6GeneveEncapAndVlanPopTableEntry(
+extern void EncodeV6GeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6GeneveEncapTableEntry(
+extern void EncodeV6GeneveEncapTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
@@ -138,58 +138,60 @@ extern void PrepareRxTunnelSrcPortTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                      const struct tunnel_info& tunnel_info,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry);
-
-extern void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry);
-
-extern void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct src_port_info& sp,
+extern void EncodeRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                     const struct tunnel_info& tunnel_info,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry);
 
-extern void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry,
-                                      uint32_t sp,
-                                      const ::p4::config::v1::P4Info& p4info);
+extern void EncodeV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
 
-extern void PrepareV6TunnelTermTableEntry(
-    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern void EncodeSrcPortTableEntry(p4::v1::TableEntry* table_entry,
+                                    const struct src_port_info& sp,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry);
 
-extern void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+extern void EncodeTxAccVsiTableEntry(p4::v1::TableEntry* table_entry,
+                                     uint32_t sp,
+                                     const ::p4::config::v1::P4Info& p4info);
+
+extern void EncodeV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
+
+extern void EncodeVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                                    const uint16_t vlan_id,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry);
+
+extern void EncodeVlanPushTableEntry(p4::v1::TableEntry* table_entry,
                                      const uint16_t vlan_id,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry);
 
-extern void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
-                                      const uint16_t vlan_id,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry);
-
-extern void PrepareVxlanDecapModTableEntry(
+extern void EncodeVxlanDecapModTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareVxlanDecapModAndVlanPushTableEntry(
+extern void EncodeVxlanDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareVxlanEncapAndVlanPopTableEntry(
+extern void EncodeVxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6VxlanEncapAndVlanPopTableEntry(
+extern void EncodeV6VxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6VxlanEncapTableEntry(
-    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern void EncodeV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
 
 #endif  // ES2K_TARGET
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbRxVlanTableEntry().
+// Unit test for EncodeFdbRxVlanTableEntry().
 // DPDK version.
 
 #include <stdint.h>
@@ -131,7 +131,7 @@ class DpdkFdbRxVlanTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbRxVlanTableEntry()
+// EncodeFdbRxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(DpdkFdbRxVlanTest, remove_entry) {
@@ -139,8 +139,8 @@ TEST_F(DpdkFdbRxVlanTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert
@@ -156,8 +156,8 @@ TEST_F(DpdkFdbRxVlanTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTxVlanTableEntry().
+// Unit test for EncodeFdbTxVlanTableEntry().
 // DPDK edition.
 
 #include <stdint.h>
@@ -128,7 +128,7 @@ class DpdkFdbTxVlanTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbTxVlanTableEntry()
+// EncodeFdbTxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(DpdkFdbTxVlanTest, remove_entry) {
@@ -136,8 +136,8 @@ TEST_F(DpdkFdbTxVlanTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
 
   // Assert
   CheckDetail();
@@ -152,8 +152,8 @@ TEST_F(DpdkFdbTxVlanTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTableEntryforV4VxlanTunnel().
+// Unit test for EncodeFdbTableEntryforV4VxlanTunnel().
 // DPDK version.
 
 #include <arpa/inet.h>
@@ -171,8 +171,8 @@ TEST_F(DpdkFdbTxVxlanTest, remove_entry) {
   InitFdbInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       REMOVE_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -187,8 +187,8 @@ TEST_F(DpdkFdbTxVxlanTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareTunnelTermTableEntry().
+// Unit test for EncodeTunnelTermTableEntry().
 // DPDK edition.
 
 #define DUMP_JSON
@@ -182,7 +182,7 @@ TEST_F(DpdkTunnelTermTest, vxlan_remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -196,7 +196,7 @@ TEST_F(DpdkTunnelTermTest, vxlan_insert_entry) {
   InitAction();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanEncapTableEntry().
+// Unit test for EncodeVxlanEncapTableEntry().
 // DPDK edition.
 
 #define DUMP_JSON
@@ -189,7 +189,7 @@ TEST_F(DpdkVxlanEncapTest, remove_entry) {
   InitTunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -204,7 +204,7 @@ TEST_F(DpdkVxlanEncapTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/config_decap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_decap_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigDecapTableEntry().
+// Unit test for WriteDecapTableEntry().
 
 // Core functionality is handled by Es2kPrepareDecapTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -43,8 +43,7 @@ TEST_F(ConfigDecapTableEntryTest, ConfigDecapTableEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status =
-      ConfigDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -62,8 +61,7 @@ TEST_F(ConfigDecapTableEntryTest, ConfigDecapTableEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status =
-      ConfigDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_encap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_encap_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigEncapTableEntry().
+// Unit test for WriteEncapTableEntry().
 
 // Core functionality is handled by Es2kPrepareEncapTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -23,13 +23,13 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class ConfigEncapTableEntryTest : public BaseTunnelInfoTest {
+class WriteEncapTableEntryTest : public BaseTunnelInfoTest {
  public:
-  ConfigEncapTableEntryTest() {}
-  virtual ~ConfigEncapTableEntryTest() = default;
+  WriteEncapTableEntryTest() {}
+  virtual ~WriteEncapTableEntryTest() = default;
 };
 
-TEST_F(ConfigEncapTableEntryTest, configEncapTableEntryFailure) {
+TEST_F(WriteEncapTableEntryTest, configEncapTableEntryFailure) {
   constexpr char ERROR_MESSAGE[] = "sendWriteRequest failed";
 
   struct tunnel_info tunnel_info = {0};
@@ -43,15 +43,14 @@ TEST_F(ConfigEncapTableEntryTest, configEncapTableEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status =
-      ConfigEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
       << status.message();
 }
 
-TEST_F(ConfigEncapTableEntryTest, configEncapTableEntrySuccess) {
+TEST_F(WriteEncapTableEntryTest, configEncapTableEntrySuccess) {
   struct tunnel_info tunnel_info = {0};
   InitV4TunnelInfo(tunnel_info);
   InitVxlanTagged(tunnel_info);
@@ -62,8 +61,7 @@ TEST_F(ConfigEncapTableEntryTest, configEncapTableEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status =
-      ConfigEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_rx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_rx_vlan_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ConfigFdbRxVlanTableEntry().
 
-// Core functionality is handled by PrepareFdbRxVlanTableEntry(),
+// Core functionality is handled by EncodeFdbRxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_rx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_rx_vlan_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbRxVlanTableEntry().
+// Unit test for WriteFdbRxVlanTableEntry().
 
 // Core functionality is handled by EncodeFdbRxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -51,7 +51,7 @@ TEST_F(ConfigFdbRxVlanTableEntryTest, configFdbRxVlanEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -69,7 +69,7 @@ TEST_F(ConfigFdbRxVlanTableEntryTest, configFdbRxVlanEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_smac_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_smac_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ConfigFdbSmacTableEntry().
 
-// Core functionality is handled by PrepareFdbSmacTableEntry(),
+// Core functionality is handled by EncodeFdbSmacTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_smac_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_smac_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbSmacTableEntry().
+// Unit test for WriteFdbSmacTableEntry().
 
 // Core functionality is handled by EncodeFdbSmacTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -51,7 +51,7 @@ TEST_F(ConfigFdbSmacTableEntryTest, configFdbSmacEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -69,7 +69,7 @@ TEST_F(ConfigFdbSmacTableEntryTest, configFdbSmacEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_tunnel_table_entry_test.cc
@@ -3,8 +3,8 @@
 
 // Unit test for ConfigFdbTunnelTableEntry().
 
-// Core functionality is handled by PrepareFdbTableEntryforV4VxlanTunnel()
-// or PrepareFdbTableEntryforV4GeneveTunnel, which are tested separately.
+// Core functionality is handled by EncodeFdbTableEntryforV4VxlanTunnel()
+// or EncodeFdbTableEntryforV4GeneveTunnel, which are tested separately.
 // This is a test of the non-core functionality.
 
 #include <absl/status/status.h>

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_tunnel_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbTunnelTableEntry().
+// Unit test for WriteFdbTunnelTableEntry().
 
 // Core functionality is handled by EncodeFdbTableEntryforV4VxlanTunnel()
 // or EncodeFdbTableEntryforV4GeneveTunnel, which are tested separately.
@@ -53,7 +53,7 @@ TEST_F(ConfigFdbTunnelTableEntryTest, configFdbTunnelEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -73,7 +73,7 @@ TEST_F(ConfigFdbTunnelTableEntryTest, configFdbTunnelEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_tx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_tx_vlan_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbTxVlanTableEntry().
+// Unit test for WriteFdbTxVlanTableEntry().
 
 // Core functionality is handled by EncodeFdbTxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -51,7 +51,7 @@ TEST_F(ConfigFdbTxVlanTableEntryTest, configFdbTxVlanEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -69,7 +69,7 @@ TEST_F(ConfigFdbTxVlanTableEntryTest, configFdbTxVlanEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_fdb_tx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_fdb_tx_vlan_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ConfigFdbTxVlanTableEntry().
 
-// Core functionality is handled by PrepareFdbTxVlanTableEntry(),
+// Core functionality is handled by EncodeFdbTxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ConfigTunnelTermTableEntry (common)
 
-// Core functionality is handled by PrepareL2ToTunnelV4(),
+// Core functionality is handled by EncodeL2ToTunnelV4(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_tunnel_term_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigTunnelTermTableEntry (common)
+// Unit test for WriteTunnelTermTableEntry (common)
 
 // Core functionality is handled by EncodeL2ToTunnelV4(),
 // which is tested separately. This is a test of the non-core
@@ -42,7 +42,7 @@ TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+      WriteTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -61,7 +61,7 @@ TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+      WriteTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_vlan_pop_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_vlan_pop_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ConfigVlanPopTableEntry().
 
-// Core functionality is handled by PrepareVlanPopTableEntry(),
+// Core functionality is handled by EncodeVlanPopTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/config_vlan_pop_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_vlan_pop_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigVlanPopTableEntry().
+// Unit test for WriteVlanPopTableEntry().
 
 // Core functionality is handled by EncodeVlanPopTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -40,7 +40,7 @@ TEST_F(ConfigVlanPopTableEntryTest, configVlanPushEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status = ConfigVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -56,7 +56,7 @@ TEST_F(ConfigVlanPopTableEntryTest, configVlanPushEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status = ConfigVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_vlan_push_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_vlan_push_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ConfigVlanPushTableEntry().
 
-// Core functionality is handled by PrepareVlanPushTableEntry(),
+// Core functionality is handled by EncodeVlanPushTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/config_vlan_push_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_vlan_push_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigVlanPushTableEntry().
+// Unit test for WriteVlanPushTableEntry().
 
 // Core functionality is handled by EncodeVlanPushTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -40,7 +40,7 @@ TEST_F(ConfigVlanPushTableEntryTest, configVlanPushEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status = ConfigVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -56,7 +56,7 @@ TEST_F(ConfigVlanPushTableEntryTest, configVlanPushEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status = ConfigVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/config_vsi_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_vsi_src_port_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ConfigVlanPopTableEntry().
 
-// Core functionality is handled by PrepareSrcPortTableEntry(),
+// Core functionality is handled by EncodeSrcPortTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/config_vsi_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/config_vsi_src_port_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigVlanPopTableEntry().
+// Unit test for WriteVlanPopTableEntry().
 
 // Core functionality is handled by EncodeSrcPortTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -49,7 +49,7 @@ TEST_F(ConfigVsiSrcPortEntryTest, configVsiSrcPortEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
+      WriteVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -67,7 +67,7 @@ TEST_F(ConfigVsiSrcPortEntryTest, configVsiSrcPortEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
+      WriteVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareDstIpMacMapTableEntry().
+// Unit test for EncodeDstIpMacMapTableEntry().
 
 //#define DUMP_JSON
 
@@ -159,8 +159,8 @@ TEST_F(DstIpMacMapTableTest, remove_entry) {
   InitMapInfo();
 
   // Act
-  PrepareDstIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
-                               detail);
+  EncodeDstIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
+                              detail);
   DumpTableEntry();
 
   // Assert
@@ -176,8 +176,8 @@ TEST_F(DstIpMacMapTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareDstIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
-                               detail);
+  EncodeDstIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
+                              detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_config_dst_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_config_dst_ip_mac_map_test.cc
@@ -2,7 +2,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigDstIpMacMapTableEntry(). [es2k]
+// Unit test for WriteDstIpMacMapTableEntry(). [es2k]
 
 #include <absl/status/status.h>
 
@@ -40,7 +40,7 @@ TEST_F(Es2kConfigDstIpMacMapTest, configDstIpMacMapWriteFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigDstIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
+      WriteDstIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -58,7 +58,7 @@ TEST_F(Es2kConfigDstIpMacMapTest, configDstIpMacMapWriteSuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigDstIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
+      WriteDstIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_config_l2_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_config_l2_tunnel_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigL2TunnelTableEntry().
+// Unit test for WriteL2TunnelTableEntry().
 
 // Core functionality is provided by PrepareL2TunnelTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -44,7 +44,7 @@ TEST_F(ConfigL2TunnelTableEntryTest, ConfigL2TunnelTableEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -63,7 +63,7 @@ TEST_F(ConfigL2TunnelTableEntryTest, ConfigL2TunnelTableEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_config_rx_tunnel_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_config_rx_tunnel_port_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigRxTunnelSrcPortTableEntry().
+// Unit test for WriteRxTunnelSrcPortTableEntry().
 
 // Core functionality is handled by PrepareRxTunnelSrcPortTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -41,8 +41,8 @@ TEST_F(Es2kConfigRxTunnelPortEntryTest, configRxTunnelEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status = ConfigRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
-                                                INSERT_ENTRY);
+  auto status =
+      WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -60,8 +60,8 @@ TEST_F(Es2kConfigRxTunnelPortEntryTest, configRxTunnelEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status = ConfigRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
-                                                INSERT_ENTRY);
+  auto status =
+      WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_config_src_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_config_src_ip_mac_map_test.cc
@@ -2,7 +2,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigSrcIpMacMapTableEntry(). [es2k]
+// Unit test for WriteSrcIpMacMapTableEntry(). [es2k]
 
 #include <absl/status/status.h>
 
@@ -40,7 +40,7 @@ TEST_F(Es2kConfigSrcIpMacMapTest, configSrcIpMacMapWriteFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigSrcIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
+      WriteSrcIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -58,7 +58,7 @@ TEST_F(Es2kConfigSrcIpMacMapTest, configSrcIpMacMapWriteSuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigSrcIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
+      WriteSrcIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/es2k_update_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/es2k_update_src_port_test.cc
@@ -69,7 +69,7 @@ class Es2kUpdateSrcPortTest : public ::testing::Test {
 };
 
 /**
- * GetTxAccVsiTableEntry failure path.
+ * ReadTxAccVsiTableEntry failure path.
  */
 TEST_F(Es2kUpdateSrcPortTest, getTxAccVsiEntryFailure) {
   constexpr char VSI_LOOKUP_FAILED[] = "Not found in VSI table";
@@ -91,7 +91,7 @@ TEST_F(Es2kUpdateSrcPortTest, getTxAccVsiEntryFailure) {
 }
 
 /**
- * GetTxAccVsiTableEntry success path.
+ * ReadTxAccVsiTableEntry success path.
  */
 TEST_F(Es2kUpdateSrcPortTest, getTxAccVsiEntrySuccess) {
   struct mac_learning_info learn_info = {0};

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_fdb_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_fdb_entry_test.cc
@@ -155,7 +155,7 @@ TEST_F(Es2kConfigFdbEntryTest, deleteVxlanTunnelTableEntry) {
       .WillOnce(
           DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
   EXPECT_CALL(client, sendReadRequest)
-      .WillOnce(Return(absl::NotFoundError("GetFdbTunnelTableEntry failed")));
+      .WillOnce(Return(absl::NotFoundError("ReadFdbTunnelTableEntry failed")));
   EXPECT_CALL(client, sendWriteRequest)
       .WillRepeatedly(Return(absl::OkStatus()));
 
@@ -181,7 +181,7 @@ TEST_F(Es2kConfigFdbEntryTest, insertVxlanTunnelTableEntry) {
       .WillOnce(
           DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
   EXPECT_CALL(client, sendReadRequest)
-      .WillOnce(Return(absl::NotFoundError("GetFdbTunnelTableEntry failed")));
+      .WillOnce(Return(absl::NotFoundError("ReadFdbTunnelTableEntry failed")));
   EXPECT_CALL(client, sendWriteRequest)
       .WillRepeatedly(Return(absl::OkStatus()));
 
@@ -191,12 +191,12 @@ TEST_F(Es2kConfigFdbEntryTest, insertVxlanTunnelTableEntry) {
 }
 
 /**
- * Exercises ConfigFdbVlanEntry with the GetTxAccVsiTableEntry
+ * Exercises ConfigFdbVlanEntry with the ReadTxAccVsiTableEntry
  * failure path.
  */
 TEST_F(Es2kConfigFdbEntryTest, insertVlanEntryVsiNotFound) {
-  constexpr char VLAN_LOOKUP_FAILED[] = "GetFdbVlanTableEntry failed";
-  constexpr char VSI_LOOKUP_FAILED[] = "GetTxAccVsiTableEntry failed";
+  constexpr char VLAN_LOOKUP_FAILED[] = "ReadFdbVlanTableEntry failed";
+  constexpr char VSI_LOOKUP_FAILED[] = "ReadTxAccVsiTableEntry failed";
 
   struct mac_learning_info learn_info = {0};
   InitVlanLearnInfo(learn_info);
@@ -222,11 +222,11 @@ TEST_F(Es2kConfigFdbEntryTest, insertVlanEntryVsiNotFound) {
 }
 
 /**
- * Exercises ConfigFdbVlanEntry with the GetTxAccVsiTableEntry
+ * Exercises ConfigFdbVlanEntry with the ReadTxAccVsiTableEntry
  * success path.
  */
 TEST_F(Es2kConfigFdbEntryTest, insertVlanEntryVsiFound) {
-  constexpr char VLAN_LOOKUP_FAILED[] = "GetFdbVlanTableEntry failed";
+  constexpr char VLAN_LOOKUP_FAILED[] = "ReadFdbVlanTableEntry failed";
 
   struct mac_learning_info learn_info = {0};
   InitVlanLearnInfo(learn_info);

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_ip_mac_map_test.cc
@@ -160,7 +160,7 @@ TEST_F(Es2kConfigIpMacMapTest, getVmSrcTableNeitherFound) {
 }
 
 /**
- * Exercises the ConfigSrcIpMacMapTableEntry() failure path.
+ * Exercises the WriteSrcIpMacMapTableEntry() failure path.
  */
 TEST_F(Es2kConfigIpMacMapTest, ConfigSrcIpMacMapTableEntryFailure) {
   constexpr char ERROR_MESSAGE[] = "sendReadRequest";
@@ -176,14 +176,14 @@ TEST_F(Es2kConfigIpMacMapTest, ConfigSrcIpMacMapTableEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigSrcIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
+      WriteSrcIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
 
   EXPECT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE);
 }
 
 /**
- * Exercises the ConfigDstIpMacMapTableEntry() failure path.
+ * Exercises the WriteDstIpMacMapTableEntry() failure path.
  */
 TEST_F(Es2kConfigIpMacMapTest, configDstIpMacMapTableEntryFailure) {
   constexpr char ERROR_MESSAGE[] = "sendReadRequest";
@@ -199,7 +199,7 @@ TEST_F(Es2kConfigIpMacMapTest, configDstIpMacMapTableEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigDstIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
+      WriteDstIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
 
   EXPECT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE);

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_ip_mac_map_test.cc
@@ -108,7 +108,7 @@ TEST_F(Es2kConfigIpMacMapTest, getPipelineConfigFailure) {
 }
 
 /**
- * Exercises the GetVmSrcTableEntry() both-found path.
+ * Exercises the ReadVmSrcTableEntry() both-found path.
  */
 TEST_F(Es2kConfigIpMacMapTest, getVmSrcTableBothFound) {
   struct ip_mac_map_info map_info = {0};
@@ -133,7 +133,7 @@ TEST_F(Es2kConfigIpMacMapTest, getVmSrcTableBothFound) {
 }
 
 /**
- * Exercises the GetVmSrcTableEntry() neither-found path.
+ * Exercises the ReadVmSrcTableEntry() neither-found path.
  */
 TEST_F(Es2kConfigIpMacMapTest, getVmSrcTableNeitherFound) {
   struct ip_mac_map_info map_info = {0};

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_src_port_entry_test.cc
@@ -108,10 +108,10 @@ TEST_F(Es2kConfigSrcPortEntryTest, getPipelineConfigFailure) {
 }
 
 /**
- * Exercises GetTxAccVsiTableEntry() error path.
+ * Exercises ReadTxAccVsiTableEntry() error path.
  */
 TEST_F(Es2kConfigSrcPortEntryTest, getTxAccVsiTableEntryFailure) {
-  constexpr char ERROR_MESSAGE[] = "GetTxAccVsiTableEntry";
+  constexpr char ERROR_MESSAGE[] = "ReadTxAccVsiTableEntry";
   struct src_port_info port_info = {0};
   InitSrcPortInfo(port_info);
 

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_entry_test.cc
@@ -131,14 +131,14 @@ TEST_F(Es2kConfigTunnelEntryTest, getPipelineConfigFailure) {
 }
 
 //----------------------------------------------------------------------
-// ConfigEncapTableEntry
+// WriteEncapTableEntry
 //----------------------------------------------------------------------
 
 /**
- * Exercises ConfigEncapTableEntry() error path.
+ * Exercises WriteEncapTableEntry() error path.
  */
 TEST_F(Es2kConfigTunnelEntryTest, encapTableWriteFailure) {
-  constexpr char ERROR_MESSAGE[] = "ConfigEncapTableEntry";
+  constexpr char ERROR_MESSAGE[] = "WriteEncapTableEntry";
 
   struct tunnel_info tunnel_info = {0};
   InitIpv4TunnelInfo(tunnel_info);
@@ -164,7 +164,7 @@ TEST_F(Es2kConfigTunnelEntryTest, encapTableWriteFailure) {
 }
 
 /**
- * Exercises ConfigEncapTableEntry() happy path and
+ * Exercises WriteEncapTableEntry() happy path and
  * WriteDecapTableEntry() error path.
  */
 TEST_F(Es2kConfigTunnelEntryTest, decapTableWriteFailure) {
@@ -183,7 +183,7 @@ TEST_F(Es2kConfigTunnelEntryTest, decapTableWriteFailure) {
       .WillRepeatedly(
           DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
   EXPECT_CALL(client, sendWriteRequest)
-      .WillOnce(Return(absl::OkStatus()))  // ConfigEncapTableEntry
+      .WillOnce(Return(absl::OkStatus()))  // WriteEncapTableEntry
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
@@ -218,7 +218,7 @@ TEST_F(Es2kConfigTunnelEntryTest, tunnelTermTableWriteFailure) {
       .WillRepeatedly(
           DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
   EXPECT_CALL(client, sendWriteRequest)
-      .WillOnce(Return(absl::OkStatus()))  // ConfigEncapTableEntry
+      .WillOnce(Return(absl::OkStatus()))  // WriteEncapTableEntry
       .WillOnce(Return(absl::OkStatus()))  // WriteDecapTableEntry
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_tunnel_entry_test.cc
@@ -165,10 +165,10 @@ TEST_F(Es2kConfigTunnelEntryTest, encapTableWriteFailure) {
 
 /**
  * Exercises ConfigEncapTableEntry() happy path and
- * ConfigDecapTableEntry() error path.
+ * WriteDecapTableEntry() error path.
  */
 TEST_F(Es2kConfigTunnelEntryTest, decapTableWriteFailure) {
-  constexpr char ERROR_MESSAGE[] = "ConfigDecapTableEntry";
+  constexpr char ERROR_MESSAGE[] = "WriteDecapTableEntry";
 
   struct tunnel_info tunnel_info = {0};
   InitIpv4TunnelInfo(tunnel_info);
@@ -195,15 +195,15 @@ TEST_F(Es2kConfigTunnelEntryTest, decapTableWriteFailure) {
 }
 
 //----------------------------------------------------------------------
-// ConfigDecapTableEntry
+// WriteDecapTableEntry
 //----------------------------------------------------------------------
 
 /**
- * Exercises ConfigDecapTableEntry() happy path and
- * ConfigTunnelTermTableEntry() error path.
+ * Exercises WriteDecapTableEntry() happy path and
+ * WriteTunnelTermTableEntry() error path.
  */
 TEST_F(Es2kConfigTunnelEntryTest, tunnelTermTableWriteFailure) {
-  constexpr char ERROR_MESSAGE[] = "ConfigTunnelTermTableEntry";
+  constexpr char ERROR_MESSAGE[] = "WriteTunnelTermTableEntry";
 
   struct tunnel_info tunnel_info = {0};
   InitIpv4TunnelInfo(tunnel_info);
@@ -219,7 +219,7 @@ TEST_F(Es2kConfigTunnelEntryTest, tunnelTermTableWriteFailure) {
           DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::OkStatus()))  // ConfigEncapTableEntry
-      .WillOnce(Return(absl::OkStatus()))  // ConfigDecapTableEntry
+      .WillOnce(Return(absl::OkStatus()))  // WriteDecapTableEntry
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
@@ -231,11 +231,11 @@ TEST_F(Es2kConfigTunnelEntryTest, tunnelTermTableWriteFailure) {
 }
 
 //----------------------------------------------------------------------
-// ConfigTunnelTermTableEntry
+// WriteTunnelTermTableEntry
 //----------------------------------------------------------------------
 
 /**
- * Exercises ConfigTunnelTermTableEntry() happy path.
+ * Exercises WriteTunnelTermTableEntry() happy path.
  */
 TEST_F(Es2kConfigTunnelEntryTest, tunnelTermTableWriteSuccess) {
   struct tunnel_info tunnel_info = {0};

--- a/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/extra/es2k_config_vlan_entry_test.cc
@@ -78,10 +78,10 @@ TEST_F(Es2kConfigVlanEntryTest, getPipelineConfigFailure) {
 }
 
 /**
- * Exercises the ConfigVlanPushTableEntry error path.
+ * Exercises the WriteVlanPushTableEntry error path.
  */
 TEST_F(Es2kConfigVlanEntryTest, configVlanPushTableEntryFailure) {
-  constexpr char PUSH_ENTRY_ERROR[] = "ConfigVlanPushTableEntry";
+  constexpr char PUSH_ENTRY_ERROR[] = "WriteVlanPushTableEntry";
   constexpr uint16_t vlan_id = VLAN_ID;
 
   ::p4::config::v1::P4Info expected_p4info;
@@ -101,10 +101,10 @@ TEST_F(Es2kConfigVlanEntryTest, configVlanPushTableEntryFailure) {
 }
 
 /**
- * Exercises the ConfigVlanPopTableEntry error path.
+ * Exercises the WriteVlanPopTableEntry error path.
  */
 TEST_F(Es2kConfigVlanEntryTest, configVlanPopTableEntryFailure) {
-  constexpr char POP_ENTRY_ERROR[] = "ConfigVlanPopTableEntry";
+  constexpr char POP_ENTRY_ERROR[] = "WriteVlanPopTableEntry";
   constexpr uint16_t vlan_id = VLAN_ID;
 
   ::p4::config::v1::P4Info expected_p4info;
@@ -116,7 +116,7 @@ TEST_F(Es2kConfigVlanEntryTest, configVlanPopTableEntryFailure) {
       .WillRepeatedly(
           DoAll(SetArgPointee<0>(expected_p4info), Return(absl::OkStatus())));
   EXPECT_CALL(client, sendWriteRequest)
-      .WillOnce(Return(absl::OkStatus()))  // ConfigVlanPushTableEntry
+      .WillOnce(Return(absl::OkStatus()))  // WriteVlanPushTableEntry
       .WillOnce(Return(absl::InternalError(POP_ENTRY_ERROR)));
 
   auto status = DoConfigVlanEntry(client, vlan_id, INSERT_ENTRY, GRPC_ADDR);

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbRxVlanTableEntry()
+// Unit test for EncodeFdbRxVlanTableEntry()
 
 #include <stdint.h>
 
@@ -143,7 +143,7 @@ class FdbRxVlanEntryTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbRxVlanTableEntry()
+// EncodeFdbRxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(FdbRxVlanEntryTest, remove_entry) {
@@ -151,8 +151,8 @@ TEST_F(FdbRxVlanEntryTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert
@@ -168,8 +168,8 @@ TEST_F(FdbRxVlanEntryTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbSmacTableEntry()
+// Unit test for EncodeFdbSmacTableEntry()
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -125,8 +125,7 @@ TEST_F(FdbSmacEntryTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                           detail);
+  EncodeFdbSmacTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -140,8 +139,7 @@ TEST_F(FdbSmacEntryTest, insert_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                           detail);
+  EncodeFdbSmacTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTableEntryforV4GeneveTunnel().
+// Unit test for EncodeFdbTableEntryforV4GeneveTunnel().
 
 #include <stdint.h>
 
@@ -192,8 +192,8 @@ TEST_F(FdbTxGeneveEntryTest, remove_v4_tagged_entry) {
   InitV4NativeTagged(SET_GENEVE_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        REMOVE_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -208,8 +208,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v4_tagged_entry) {
   InitV4NativeTagged(SET_GENEVE_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -222,8 +222,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v4_untagged_entry) {
   InitV4NativeUntagged(POP_VLAN_SET_GENEVE_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -236,8 +236,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_tagged_entry) {
   InitV6NativeTagged(SET_GENEVE_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -250,8 +250,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_untagged_entry) {
   InitV6NativeUntagged(POP_VLAN_SET_GENEVE_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -267,8 +267,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_untagged_entry_20_bit_vni) {
   learn_info.tnl_info.vni = 0xFACED;
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTxVlanTableEntry()
+// Unit test for EncodeFdbTxVlanTableEntry()
 //
 // TODO(derek): port and vlan_ptr parameter values are truncated to
 // 8 bits. Need to fix or document why this is correct.
@@ -205,7 +205,7 @@ class FdbTxVlanEntryTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbTxVlanTableEntry()
+// EncodeFdbTxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(FdbTxVlanEntryTest, remove_entry) {
@@ -213,8 +213,8 @@ TEST_F(FdbTxVlanEntryTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
 
   // Assert
   CheckDetail();
@@ -229,8 +229,8 @@ TEST_F(FdbTxVlanEntryTest, insert_untagged_entry) {
   InitUntagged();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
 
   // Assert
   CheckTableEntry();
@@ -243,8 +243,8 @@ TEST_F(FdbTxVlanEntryTest, insert_tagged_entry) {
   InitTagged();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
@@ -193,8 +193,8 @@ TEST_F(FdbTxVxlanEntryTest, remove_v4_tagged_entry) {
   InitV4NativeTagged(SET_VXLAN_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       REMOVE_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -209,8 +209,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v4_tagged_entry) {
   InitV4NativeTagged(SET_VXLAN_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -223,8 +223,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v4_untagged_entry) {
   InitV4NativeUntagged(POP_VLAN_SET_VXLAN_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -237,8 +237,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v6_tagged_entry) {
   InitV6NativeTagged(SET_VXLAN_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -251,8 +251,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v6_untagged_entry) {
   InitV6NativeUntagged(POP_VLAN_SET_VXLAN_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveDecapModTableEntry()
+// Unit test for EncodeGeneveDecapModTableEntry()
 
 #include <stdint.h>
 
@@ -99,8 +99,8 @@ TEST_F(GeneveDecapModTableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                  REMOVE_ENTRY);
+  EncodeGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                 REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -114,8 +114,8 @@ TEST_F(GeneveDecapModTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                  INSERT_ENTRY);
+  EncodeGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                 INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveDecapModAndVlanPushTableEntry().
+// Unit test for EncodeGeneveDecapModAndVlanPushTableEntry().
 
 #include <stdint.h>
 
@@ -159,8 +159,8 @@ TEST_F(GeneveDecapModVlanPushTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                             REMOVE_ENTRY);
+  EncodeGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                            REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -174,8 +174,8 @@ TEST_F(GeneveDecapModVlanPushTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                             INSERT_ENTRY);
+  EncodeGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                            INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -189,8 +189,8 @@ TEST_F(GeneveDecapModVlanPushTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                             INSERT_ENTRY);
+  EncodeGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                            INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveEncapTableEntry().
+// Unit test for EncodeGeneveEncapTableEntry().
 
 #include <stdint.h>
 
@@ -151,7 +151,7 @@ class GeneveEncapV4TableTest : public IpTunnelTest {
 };
 
 //----------------------------------------------------------------------
-// Test PrepareGeneveEncapTableEntry()
+// Test EncodeGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(GeneveEncapV4TableTest, remove_entry) {
@@ -159,7 +159,7 @@ TEST_F(GeneveEncapV4TableTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -174,7 +174,7 @@ TEST_F(GeneveEncapV4TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -191,7 +191,7 @@ TEST_F(GeneveEncapV4TableTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveEncapAndVlanPopTableEntry().
+// Unit test for EncodeGeneveEncapAndVlanPopTableEntry().
 
 #define DUMP_JSON
 
@@ -168,8 +168,8 @@ TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                         REMOVE_ENTRY);
+  EncodeGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                        REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -184,8 +184,8 @@ TEST_F(GeneveEncapV4VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                         INSERT_ENTRY);
+  EncodeGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                        INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6GeneveEncapTableEntry().
+// Unit test for EncodeV6GeneveEncapTableEntry().
 
 #define DUMP_JSON
 
@@ -174,8 +174,8 @@ TEST_F(GeneveEncapV6TableTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 REMOVE_ENTRY);
+  EncodeV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -190,8 +190,8 @@ TEST_F(GeneveEncapV6TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6GeneveEncapAndVlanPopTableEntry().
+// Unit test for EncodeV6GeneveEncapAndVlanPopTableEntry().
 
 #include <stdint.h>
 
@@ -191,8 +191,8 @@ TEST_F(GeneveEncapV6VlanPopTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                           REMOVE_ENTRY);
+  EncodeV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -206,8 +206,8 @@ TEST_F(GeneveEncapV6VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                           INSERT_ENTRY);
+  EncodeV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -223,8 +223,8 @@ TEST_F(GeneveEncapV6VlanPopTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                           INSERT_ENTRY);
+  EncodeV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/get_fdb_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_fdb_tunnel_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for GetL2ToTunnelV4TableEntry().
+// Unit test for ReadL2ToTunnelV4TableEntry().
 
 // Core functionality is handled by Es2kPrepareTunnelTermTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -67,7 +67,7 @@ TEST_F(GetFdbTunnelEntryTest, getFdbTableEntryFailure) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(Return(absl::NotFoundError(REQUEST_FAILED)));
 
-  auto response = GetFdbTunnelTableEntry(client, learn_info, p4info);
+  auto response = ReadFdbTunnelTableEntry(client, learn_info, p4info);
   auto status = response.status();
 
   ASSERT_FALSE(status.ok());
@@ -86,7 +86,7 @@ TEST_F(GetFdbTunnelEntryTest, getFdbTableEntrySuccess) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(GoodReadResponse));
 
-  auto response = GetFdbTunnelTableEntry(client, learn_info, p4info);
+  auto response = ReadFdbTunnelTableEntry(client, learn_info, p4info);
 
   ASSERT_TRUE(response.ok()) << response.status();
 }

--- a/ovs-p4rt/sidecar/tests/es2k/get_fdb_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_fdb_vlan_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for GetFdbVlanTableEntry().
+// Unit test for ReadFdbVlanTableEntry().
 
 // Core functionality is handled by EncodeFdbTxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -67,7 +67,7 @@ TEST_F(GetFdbVlanEntryTest, getFdbVlanTableEntryFailure) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(Return(absl::NotFoundError(REQUEST_FAILED)));
 
-  auto response = GetFdbVlanTableEntry(client, learn_info, p4info);
+  auto response = ReadFdbVlanTableEntry(client, learn_info, p4info);
   auto status = response.status();
 
   ASSERT_FALSE(status.ok());
@@ -86,7 +86,7 @@ TEST_F(GetFdbVlanEntryTest, getFdbVlanTableEntrySuccess) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(GoodReadResponse));
 
-  auto response = GetFdbVlanTableEntry(client, learn_info, p4info);
+  auto response = ReadFdbVlanTableEntry(client, learn_info, p4info);
 
   ASSERT_TRUE(response.ok()) << response.status();
 }

--- a/ovs-p4rt/sidecar/tests/es2k/get_fdb_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_fdb_vlan_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetFdbVlanTableEntry().
 
-// Core functionality is handled by PrepareFdbTxVlanTableEntry(),
+// Core functionality is handled by EncodeFdbTxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v4_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v4_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for GetL2ToTunnelV4TableEntry().
+// Unit test for ReadL2ToTunnelV4TableEntry().
 
 // Core functionality is handled by Es2kPrepareTunnelTermTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -67,7 +67,7 @@ TEST_F(GetL2ToTunnelV4EntryTest, getL2ToTunnelV4EntryFailure) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(Return(absl::NotFoundError(REQUEST_FAILED)));
 
-  auto response = GetL2ToTunnelV4TableEntry(client, learn_info, p4info);
+  auto response = ReadL2ToTunnelV4TableEntry(client, learn_info, p4info);
   auto status = response.status();
 
   ASSERT_FALSE(status.ok());
@@ -86,7 +86,7 @@ TEST_F(GetL2ToTunnelV4EntryTest, getL2ToTunnelV4EntrySuccess) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(GoodReadResponse));
 
-  auto response = GetL2ToTunnelV4TableEntry(client, learn_info, p4info);
+  auto response = ReadL2ToTunnelV4TableEntry(client, learn_info, p4info);
 
   ASSERT_TRUE(response.ok()) << response.status();
 }

--- a/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v6_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v6_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for GetL2ToTunnelV6TableEntry().
+// Unit test for ReadL2ToTunnelV6TableEntry().
 
 // Core functionality is handled by EncodeL2ToTunnelV6(),
 // which is tested separately. This is a test of the non-core
@@ -55,7 +55,7 @@ TEST_F(GetL2ToTunnelV6EntryTest, getL2ToTunnelV6EntryFailure) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(Return(absl::NotFoundError(REQUEST_FAILED)));
 
-  auto response = GetL2ToTunnelV6TableEntry(client, learn_info, p4info);
+  auto response = ReadL2ToTunnelV6TableEntry(client, learn_info, p4info);
   auto status = response.status();
 
   ASSERT_FALSE(status.ok());
@@ -74,7 +74,7 @@ TEST_F(GetL2ToTunnelV6EntryTest, getL2ToTunnelV6EntrySuccess) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(GoodReadResponse));
 
-  auto response = GetL2ToTunnelV6TableEntry(client, learn_info, p4info);
+  auto response = ReadL2ToTunnelV6TableEntry(client, learn_info, p4info);
 
   ASSERT_TRUE(response.ok()) << response.status();
 }

--- a/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v6_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_l2_to_tunnel_v6_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetL2ToTunnelV6TableEntry().
 
-// Core functionality is handled by PrepareL2ToTunnelV6(),
+// Core functionality is handled by EncodeL2ToTunnelV6(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/get_vm_dst_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_vm_dst_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for GetVmDstTableEntry().
+// Unit test for ReadVmDstTableEntry().
 
 // Core functionality is handled by EncodeDstIpMacMapTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -50,7 +50,7 @@ TEST_F(GetVmDstTableEntryTest, getVmDstTableEntryFailure) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(Return(absl::NotFoundError(REQUEST_FAILED)));
 
-  auto response = GetVmDstTableEntry(client, map_info, p4info);
+  auto response = ReadVmDstTableEntry(client, map_info, p4info);
   auto status = response.status();
 
   ASSERT_FALSE(status.ok());
@@ -68,7 +68,7 @@ TEST_F(GetVmDstTableEntryTest, getVmDstTableEntrySuccess) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(GoodReadResponse));
 
-  auto response = GetVmDstTableEntry(client, map_info, p4info);
+  auto response = ReadVmDstTableEntry(client, map_info, p4info);
 
   ASSERT_TRUE(response.ok()) << response.status();
 }

--- a/ovs-p4rt/sidecar/tests/es2k/get_vm_dst_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_vm_dst_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetVmDstTableEntry().
 
-// Core functionality is handled by PrepareDstIpMacMapTableEntry(),
+// Core functionality is handled by EncodeDstIpMacMapTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/get_vm_src_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_vm_src_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for GetVmSrcTableEntry().
+// Unit test for ReadVmSrcTableEntry().
 
 // Core functionality is handled by EncodeSrcIpMacMapTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -50,7 +50,7 @@ TEST_F(GetVmSrcTableEntryTest, GetVmSrcTableEntryFailure) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(Return(absl::NotFoundError(REQUEST_FAILED)));
 
-  auto response = GetVmSrcTableEntry(client, map_info, p4info);
+  auto response = ReadVmSrcTableEntry(client, map_info, p4info);
   auto status = response.status();
 
   ASSERT_FALSE(status.ok());
@@ -68,7 +68,7 @@ TEST_F(GetVmSrcTableEntryTest, GetVmSrcTableEntrySuccess) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(GoodReadResponse));
 
-  auto response = GetVmSrcTableEntry(client, map_info, p4info);
+  auto response = ReadVmSrcTableEntry(client, map_info, p4info);
 
   ASSERT_TRUE(response.ok()) << response.status();
 }

--- a/ovs-p4rt/sidecar/tests/es2k/get_vm_src_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/get_vm_src_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetVmSrcTableEntry().
 
-// Core functionality is handled by PrepareSrcIpMacMapTableEntry(),
+// Core functionality is handled by EncodeSrcIpMacMapTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareL2ToTunnelV4().
+// Unit test for EncodeL2ToTunnelV4().
 
 #define DUMP_JSON
 
@@ -154,7 +154,7 @@ TEST_F(L2ToV4TunnelTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
+  EncodeL2ToTunnelV4(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
   DumpTableEntry();
 
   // Assert
@@ -170,7 +170,7 @@ TEST_F(L2ToV4TunnelTest, insert_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
+  EncodeL2ToTunnelV4(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareL2ToTunnelV6().
+// Unit test for EncodeL2ToTunnelV6().
 
 #include <iostream>
 #include <string>
@@ -115,7 +115,7 @@ TEST_F(L2ToV6TunnelTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
+  EncodeL2ToTunnelV6(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
   DumpTableEntry();
 
   // Assert
@@ -130,7 +130,7 @@ TEST_F(L2ToV6TunnelTest, insert_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
+  EncodeL2ToTunnelV6(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareRxTunnelTableEntry().
+// Unit test for EncodeRxTunnelTableEntry().
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -134,7 +134,7 @@ class RxTunnelPortV4TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareRxTunnelTableEntry()
+// EncodeRxTunnelTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(RxTunnelPortV4TableTest, remove_entry) {
@@ -142,7 +142,7 @@ TEST_F(RxTunnelPortV4TableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareRxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeRxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -156,7 +156,7 @@ TEST_F(RxTunnelPortV4TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareRxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeRxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6RxTunnelTableEntry().
+// Unit test for EncodeV6RxTunnelTableEntry().
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -166,7 +166,7 @@ class RxTunnelPortV6TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareV6RxTunnelTableEntry()
+// EncodeV6RxTunnelTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(RxTunnelPortV6TableTest, remove_entry) {
@@ -174,7 +174,7 @@ TEST_F(RxTunnelPortV6TableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -188,7 +188,7 @@ TEST_F(RxTunnelPortV6TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareSrcIpMacMapTableEntry()
+// Unit test for EncodeSrcIpMacMapTableEntry()
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -157,8 +157,8 @@ TEST_F(SrcIpMacMapTableTest, remove_entry) {
   InitMapInfo();
 
   // Act
-  PrepareSrcIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
-                               detail);
+  EncodeSrcIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
+                              detail);
 
   // Assert
   CheckDetail();
@@ -173,8 +173,8 @@ TEST_F(SrcIpMacMapTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareSrcIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
-                               detail);
+  EncodeSrcIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
+                              detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareSrcPortTableEntry()
+// Unit test for EncodeSrcPortTableEntry()
 
 #define DUMP_JSON
 
@@ -135,7 +135,7 @@ class SrcPortTableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareSrcPortTableEntry()
+// EncodeSrcPortTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(SrcPortTableTest, remove_entry) {
@@ -143,7 +143,7 @@ TEST_F(SrcPortTableTest, remove_entry) {
   InitMapInfo();
 
   // Act
-  PrepareSrcPortTableEntry(&table_entry, port_info, p4info, REMOVE_ENTRY);
+  EncodeSrcPortTableEntry(&table_entry, port_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -157,7 +157,7 @@ TEST_F(SrcPortTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareSrcPortTableEntry(&table_entry, port_info, p4info, INSERT_ENTRY);
+  EncodeSrcPortTableEntry(&table_entry, port_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
@@ -182,7 +182,7 @@ class TunnelTermV4TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareTunnelTermTableEntry() - vxlan
+// EncodeTunnelTermTableEntry() - vxlan
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV4TableTest, vxlan_remove_untagged_entry) {
@@ -191,7 +191,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_remove_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -205,7 +205,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_insert_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -218,7 +218,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_remove_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -232,7 +232,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_insert_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -240,7 +240,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_insert_tagged_entry) {
 }
 
 //----------------------------------------------------------------------
-// PrepareTunnelTermTableEntry() - geneve
+// EncodeTunnelTermTableEntry() - geneve
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV4TableTest, geneve_remove_untagged_entry) {
@@ -249,7 +249,7 @@ TEST_F(TunnelTermV4TableTest, geneve_remove_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -263,7 +263,7 @@ TEST_F(TunnelTermV4TableTest, geneve_insert_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -275,7 +275,7 @@ TEST_F(TunnelTermV4TableTest, geneve_remove_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -289,7 +289,7 @@ TEST_F(TunnelTermV4TableTest, geneve_insert_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -302,7 +302,7 @@ TEST_F(TunnelTermV4TableTest, geneve_insert_untagged_entry_with_20_bit_vni) {
   tunnel_info.vni = 0x95054;
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
@@ -220,7 +220,7 @@ class TunnelTermV6TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareV6TunnelTermTableEntry() - vxlan
+// EncodeV6TunnelTermTableEntry() - vxlan
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV6TableTest, remove_vxlan_untagged_entry) {
@@ -229,8 +229,7 @@ TEST_F(TunnelTermV6TableTest, remove_vxlan_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -244,8 +243,7 @@ TEST_F(TunnelTermV6TableTest, insert_vxlan_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -257,8 +255,7 @@ TEST_F(TunnelTermV6TableTest, remove_vxlan_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -272,15 +269,14 @@ TEST_F(TunnelTermV6TableTest, insert_vxlan_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
 }
 
 //----------------------------------------------------------------------
-// PrepareV6TunnelTermTableEntry() - geneve
+// EncodeV6TunnelTermTableEntry() - geneve
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV6TableTest, remove_geneve_untagged_entry) {
@@ -289,8 +285,7 @@ TEST_F(TunnelTermV6TableTest, remove_geneve_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -304,8 +299,7 @@ TEST_F(TunnelTermV6TableTest, insert_geneve_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -317,8 +311,7 @@ TEST_F(TunnelTermV6TableTest, remove_geneve_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -332,8 +325,7 @@ TEST_F(TunnelTermV6TableTest, insert_geneve_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareTxAccVsiTableEntry()
+// Unit test for EncodeTxAccVsiTableEntry()
 
 #include <stdint.h>
 
@@ -84,7 +84,7 @@ TEST_F(TxAccVsiTableTest, sp_8_bits) {
   info_sp = 42;
 
   // Act
-  PrepareTxAccVsiTableEntry(&table_entry, info_sp, p4info);
+  EncodeTxAccVsiTableEntry(&table_entry, info_sp, p4info);
 
   // Assert
   CheckTableEntry();
@@ -99,7 +99,7 @@ TEST_F(TxAccVsiTableTest, sp_11_bits) {
   info_sp = 0x765;
 
   // Act
-  PrepareTxAccVsiTableEntry(&table_entry, info_sp, p4info);
+  EncodeTxAccVsiTableEntry(&table_entry, info_sp, p4info);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVlanPopTableEntry()
+// Unit test for EncodeVlanPopTableEntry()
 
 #include <stdint.h>
 
@@ -93,7 +93,7 @@ TEST_F(VlanPopTableTest, remove_entry) {
   InitVlanInfo();
 
   // Act
-  PrepareVlanPopTableEntry(&table_entry, vlan_id, p4info, REMOVE_ENTRY);
+  EncodeVlanPopTableEntry(&table_entry, vlan_id, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -107,7 +107,7 @@ TEST_F(VlanPopTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVlanPopTableEntry(&table_entry, vlan_id, p4info, INSERT_ENTRY);
+  EncodeVlanPopTableEntry(&table_entry, vlan_id, p4info, INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVlanPushTableEntry().
+// Unit test for EncodeVlanPushTableEntry().
 
 #include <stdint.h>
 
@@ -24,14 +24,14 @@ class VlanPushModTableTest : public BaseTableTest {
   void InitAction() { SelectAction("vlan_push"); }
 
   void InitPushInfo() {
-    // These values are hard-coded in PrepareVlanPushTableEntry();
+    // These values are hard-coded in EncodeVlanPushTableEntry();
     constexpr uint16_t PCP = 1;
     constexpr uint16_t DEI = 0;
 
     push_info.pcp = PCP;
     push_info.dei = DEI;
 
-    // PrepareVlanPushTableEntry() encodes the value as a single byte.
+    // EncodeVlanPushTableEntry() encodes the value as a single byte.
     push_info.vlan_id = 0xAC;
   }
 
@@ -120,7 +120,7 @@ class VlanPushModTableTest : public BaseTableTest {
   }
 
   void CheckModBlobPtrMatch(const ::p4::v1::FieldMatch& match) const {
-    // TODO(derek): PrepareVlanPushTableEntry() encodes the mod_blob_ptr
+    // TODO(derek): EncodeVlanPushTableEntry() encodes the mod_blob_ptr
     // value as a single byte, which doesn't make sense. The input is
     // a vlan_id, which is bit<12>. The mod_blob ptr value is bit<24>.
     constexpr int MOD_BLOB_PTR_SIZE = 1;
@@ -163,8 +163,8 @@ TEST_F(VlanPushModTableTest, remove_entry) {
   InitPushInfo();
 
   // Act
-  PrepareVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
-                            REMOVE_ENTRY);
+  EncodeVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
+                           REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -178,8 +178,8 @@ TEST_F(VlanPushModTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
-                            INSERT_ENTRY);
+  EncodeVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
+                           INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanDecapModTableEntry().
+// Unit test for EncodeVxlanDecapModTableEntry().
 
 #include <stdint.h>
 
@@ -91,7 +91,7 @@ class VxlanDecapModTableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareVxlanDecapModTableEntry()
+// EncodeVxlanDecapModTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(VxlanDecapModTableTest, remove_entry) {
@@ -99,8 +99,8 @@ TEST_F(VxlanDecapModTableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 REMOVE_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -114,8 +114,8 @@ TEST_F(VxlanDecapModTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -128,8 +128,8 @@ TEST_F(VxlanDecapModTableTest, insert_entry_with_20_bit_vni) {
   tunnel_info.vni = 0x87124;  // 20-bit value
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -144,8 +144,8 @@ TEST_F(VxlanDecapModTableTest, insert_entry_with_24_bit_vni) {
   tunnel_info.vni = 0x871244;  // 24-bit value
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanDecapModAndVlanPushTableEntry().
+// Unit test for EncodeVxlanDecapModAndVlanPushTableEntry().
 
 #include <stdint.h>
 
@@ -159,8 +159,8 @@ TEST_F(VxlanDecapModVlanPushTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                            REMOVE_ENTRY);
+  EncodeVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                           REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -174,8 +174,8 @@ TEST_F(VxlanDecapModVlanPushTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                            INSERT_ENTRY);
+  EncodeVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                           INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -189,8 +189,8 @@ TEST_F(VxlanDecapModVlanPushTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                            INSERT_ENTRY);
+  EncodeVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                           INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanEncapTableEntry().
+// Unit test for EncodeVxlanEncapTableEntry().
 
 #define DUMP_JSON
 
@@ -168,7 +168,7 @@ TEST_F(VxlanEncapV4TableTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -183,7 +183,7 @@ TEST_F(VxlanEncapV4TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanEncapAndVlanPopTableEntry().
+// Unit test for EncodeVxlanEncapAndVlanPopTableEntry().
 
 #define DUMP_JSON
 
@@ -168,8 +168,8 @@ TEST_F(VxlanEncapV4VlanPopTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        REMOVE_ENTRY);
+  EncodeVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                       REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -184,8 +184,8 @@ TEST_F(VxlanEncapV4VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        INSERT_ENTRY);
+  EncodeVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                       INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -200,8 +200,8 @@ TEST_F(VxlanEncapV4VlanPopTest, insert_entry_24_bit_vni) {
   tunnel_info.vni = 0x95054;
 
   // Act
-  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        INSERT_ENTRY);
+  EncodeVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                       INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6VxlanEncapTableEntry().
+// Unit test for EncodeV6VxlanEncapTableEntry().
 
 #define DUMP_JSON
 
@@ -173,8 +173,7 @@ TEST_F(VxlanEncapV6TableTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -189,8 +188,7 @@ TEST_F(VxlanEncapV6TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6VxlanEncapAndVlanPopTableEntry().
+// Unit test for EncodeV6VxlanEncapAndVlanPopTableEntry().
 
 #define DUMP_JSON
 
@@ -173,8 +173,8 @@ TEST_F(VxlanEncapV6VlanPopTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                          REMOVE_ENTRY);
+  EncodeV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                         REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -189,8 +189,8 @@ TEST_F(VxlanEncapV6VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                          INSERT_ENTRY);
+  EncodeV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                         INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert


### PR DESCRIPTION
### Changes

- Renamed functions that directly encode protobufs from `Prepare` to `Encode`.
- Renamed functions that directly write protobufs from `Config` to `Write`.
- Renamed functions that directly read protobufs from `Get` to `Read`.

### Issues
This PR breaks the legacy (non-client) build because `ovsp4rt.cc` uses the old function names, and `ovsp4rt_private.h` and the unit tests use the new ones. The CI pipeline does a legacy build (as it should).

### Conclusions

- This might be worth doing, in small batches, if applied to both `ovsp4rt.cc` and `newovsp4rt.cc` at the same time.
- This will make it more difficult to upstream/downstream to/from `ipdk-io` (not that this is likely to happen).