### PR TITLE
Move BasicTest to top-level tests folder

### DIFF
--- a/ovs-p4rt/sidecar/tests/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/CMakeLists.txt
@@ -15,6 +15,68 @@ option(TEST_COVERAGE OFF "Measure unit test code coverage")
 # We can use this with ctest to filter the tests to be run.
 set_property(DIRECTORY PROPERTY LABELS ovsp4rt)
 
+set(TESTS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+#-----------------------------------------------------------------------
+# P4INFO_TEXT
+#-----------------------------------------------------------------------
+if(DPDK_TARGET)
+  set(P4INFO_TEXT dpdk/p4info_text.h)
+elseif(ES2K_TARGET)
+  set(P4INFO_TEXT es2k/p4info_text.h)
+endif()
+
+#-----------------------------------------------------------------------
+# ovsp4rt_test_main_o
+#-----------------------------------------------------------------------
+add_library(ovsp4rt_test_main_o OBJECT test_main.cc)
+
+#-----------------------------------------------------------------------
+# ovsp4rt_basic_test
+#-----------------------------------------------------------------------
+add_library(ovsp4rt_basic_test STATIC
+  basic_test.cc
+  basic_test.h
+  ${P4INFO_TEXT}
+  $<TARGET_OBJECTS:ovsp4rt_test_main_o>
+)
+
+target_include_directories(ovsp4rt_basic_test PRIVATE
+  ${CURRENT_SOURCE_DIR}
+  ${SIDECAR_SOURCE_DIR}
+  ${STRATUM_SOURCE_DIR}
+)
+
+target_link_libraries(ovsp4rt_basic_test PUBLIC
+  absl::flags_parse
+  p4runtime_proto
+  stratum_utils
+)
+
+add_library(ovsp4rt::basic_test ALIAS ovsp4rt_basic_test)
+
+#-----------------------------------------------------------------------
+# define_ovsp4rt_basic_test()
+#-----------------------------------------------------------------------
+macro(define_ovsp4rt_basic_test TARGET)
+  add_executable(${TARGET}
+    ${TARGET}.cc
+    $<TARGET_OBJECTS:ovsp4rt_test_client_o>
+  )
+
+  set_test_properties(${TARGET})
+
+  target_include_directories(${TARGET} PUBLIC
+    ${TESTS_SOURCE_DIR}
+  )
+
+  target_link_libraries(${TARGET} PUBLIC
+    ovsp4rt::basic_test
+  )
+
+  list(APPEND UNIT_TEST_NAMES ${TARGET})
+endmacro()
+
 #-----------------------------------------------------------------------
 # encode_host_port_value_test
 #-----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/tests/basic_test.cc
+++ b/ovs-p4rt/sidecar/tests/basic_test.cc
@@ -1,0 +1,25 @@
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+#include "basic_test.h"
+
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/lib/utils.h"
+
+#if defined(DPDK_TARGET)
+#include "dpdk/p4info_text.h"
+#elif defined(ES2K_TARGET)
+#include "es2k/p4info_text.h"
+#endif
+
+namespace ovsp4rt {
+
+void BasicTest::InitP4Info(::p4::config::v1::P4Info* p4info) {
+  auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
+  if (!status.ok()) {
+    std::cerr << "ParseProtoFromString: " << status << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/basic_test.h
+++ b/ovs-p4rt/sidecar/tests/basic_test.h
@@ -7,8 +7,6 @@
 #include <gtest/gtest.h>
 
 #include "p4/config/v1/p4info.pb.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
 
 namespace ovsp4rt {
 
@@ -20,11 +18,7 @@ class BasicTest : public ::testing::Test {
   BasicTest(){};
   virtual ~BasicTest() = default;
 
-  static void InitP4Info(::p4::config::v1::P4Info* p4info) {
-    auto status = stratum::ParseProtoFromString(P4INFO_TEXT, p4info);
-    EXPECT_TRUE(status.ok())
-        << "ParseProtoFromString: " << status.error_message();
-  }
+  static void InitP4Info(::p4::config::v1::P4Info* p4info);
 };
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
@@ -67,7 +67,7 @@ endmacro(define_es2k_test)
 #-----------------------------------------------------------------------
 add_library(tunnel_test_utils STATIC
   base_table_test.h
-  basic_test.h
+  ${TESTS_SOURCE_DIR}/basic_test.h
   ip_tunnel_test.h
   p4info_text.h
   test_main.cc
@@ -139,6 +139,17 @@ define_es2k_tunnel_test(vxlan_encap_v4_vlan_pop_test)
 define_es2k_tunnel_test(vxlan_encap_v6_vlan_pop_test)
 
 #-----------------------------------------------------------------------
+# basic tests
+#-----------------------------------------------------------------------
+define_ovsp4rt_basic_test(config_fdb_smac_table_entry_test)
+define_ovsp4rt_basic_test(config_fdb_rx_vlan_table_entry_test)
+define_ovsp4rt_basic_test(config_fdb_tx_vlan_table_entry_test)
+define_ovsp4rt_basic_test(config_vlan_pop_table_entry_test)
+define_ovsp4rt_basic_test(config_vlan_push_table_entry_test)
+define_ovsp4rt_basic_test(config_vsi_src_port_entry_test)
+define_ovsp4rt_basic_test(get_l2_to_tunnel_v4_entry_test)
+
+#-----------------------------------------------------------------------
 # define_es2k_config_test()
 #-----------------------------------------------------------------------
 macro(define_es2k_config_test TARGET)
@@ -159,14 +170,6 @@ endmacro()
 #-----------------------------------------------------------------------
 # Basic tests
 #-----------------------------------------------------------------------
-# ::ovsp4rt::BasicTest subclasses
-define_es2k_config_test(config_fdb_smac_table_entry_test)
-define_es2k_config_test(config_fdb_rx_vlan_table_entry_test)
-define_es2k_config_test(config_fdb_tx_vlan_table_entry_test)
-define_es2k_config_test(config_vlan_pop_table_entry_test)
-define_es2k_config_test(config_vlan_push_table_entry_test)
-define_es2k_config_test(config_vsi_src_port_entry_test)
-define_es2k_config_test(get_l2_to_tunnel_v4_entry_test)
 
 # ::testing::Test subclasses
 define_es2k_config_test(do_config_fdb_entry_test)

--- a/ovs-p4rt/sidecar/tests/test_main.cc
+++ b/ovs-p4rt/sidecar/tests/test_main.cc
@@ -1,0 +1,17 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "absl/flags/parse.h"
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+  // As part of initialization, this function parses the command line,
+  // removing any arguments that are specific to googletest.
+  testing::InitGoogleTest(&argc, argv);
+
+  // Parses the remaining command-line arguments for Abseil flags
+  // defined by the test program.
+  absl::ParseCommandLine(argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Moved the definition of the `BasicTest` base class to the `sandbox/tests` directory.