### PR TITLE
Rename Write functions

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -32,10 +32,10 @@ static inline int32_t ValidIpAddr(uint32_t nw_addr) {
 
 #ifdef ES2K_TARGET
 
-absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
-                                     const struct mac_learning_info& learn_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+absl::Status WriteFdbSmacTableEntry(ClientInterface& client,
+                                    const struct mac_learning_info& learn_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -53,7 +53,7 @@ absl::Status ConfigFdbSmacTableEntry(ClientInterface& client,
   return status;
 }
 
-// extracted from ConfigL2TunnelTableEntry
+// extracted from WriteL2TunnelTableEntry
 void PrepareL2TunnelTableEntry(p4::v1::TableEntry* table_entry,
                                const struct mac_learning_info& learn_info,
                                const ::p4::config::v1::P4Info& p4info,
@@ -66,9 +66,10 @@ void PrepareL2TunnelTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::Status ConfigL2TunnelTableEntry(
-    ClientInterface& client, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
+absl::Status WriteL2TunnelTableEntry(ClientInterface& client,
+                                     const struct mac_learning_info& learn_info,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -89,7 +90,7 @@ absl::Status ConfigL2TunnelTableEntry(
 #endif  // ES2K_TARGET
 
 // called-by: ConfigFdbVlanEntry (dpdk, es2k)
-absl::Status ConfigFdbTxVlanTableEntry(
+absl::Status WriteFdbTxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -110,7 +111,7 @@ absl::Status ConfigFdbTxVlanTableEntry(
 }
 
 // called-by: ConfigFdbVlanEntry (dpdk, es2k)
-absl::Status ConfigFdbRxVlanTableEntry(
+absl::Status WriteFdbRxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -131,7 +132,7 @@ absl::Status ConfigFdbRxVlanTableEntry(
 }
 
 #if defined(ES2K_TARGET)
-// extracted from ConfigFdbTunnelTableEntry
+// extracted from WriteFdbTunnelTableEntry
 void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
                                     const struct mac_learning_info& learn_info,
                                     const ::p4::config::v1::P4Info& p4info,
@@ -153,7 +154,7 @@ void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-absl::Status ConfigFdbTunnelTableEntry(
+absl::Status WriteFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -252,7 +253,7 @@ void PrepareV6EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
 #endif  // ES2K_TARGET
 
 #if defined(ES2K_TARGET)
-// called-by: ConfigEncapTableEntry
+// called-by: WriteEncapTableEntry
 void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
                                 const struct tunnel_info& tunnel_info,
                                 const ::p4::config::v1::P4Info& p4info,
@@ -278,10 +279,10 @@ void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
 #endif  // ES2K_TARGET
 
 // called-by: DoConfigTunnelEntry (common)
-absl::Status ConfigEncapTableEntry(ClientInterface& client,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+absl::Status WriteEncapTableEntry(ClientInterface& client,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -333,7 +334,7 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
-// called-by: ConfigDecapTableEntry
+// called-by: WriteDecapTableEntry
 void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
                                 const struct tunnel_info& tunnel_info,
                                 const ::p4::config::v1::P4Info& p4info,
@@ -347,10 +348,10 @@ void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
 }
 
 // called-by: DoConfigTunnelEntry (es2k)
-absl::Status ConfigDecapTableEntry(ClientInterface& client,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+absl::Status WriteDecapTableEntry(ClientInterface& client,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -362,10 +363,10 @@ absl::Status ConfigDecapTableEntry(ClientInterface& client,
 }
 
 // called-by: DoConfigVlanEntry (es2k)
-absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
-                                      const uint16_t vlan_id,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+absl::Status WriteVlanPushTableEntry(ClientInterface& client,
+                                     const uint16_t vlan_id,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -377,10 +378,10 @@ absl::Status ConfigVlanPushTableEntry(ClientInterface& client,
 }
 
 // called-by: DoConfigVlanEntry (es2k)
-absl::Status ConfigVlanPopTableEntry(ClientInterface& client,
-                                     const uint16_t vlan_id,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+absl::Status WriteVlanPopTableEntry(ClientInterface& client,
+                                    const uint16_t vlan_id,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -520,10 +521,10 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
 }
 
 // called-by: DoConfigSrcPortEntry (es2k)
-absl::Status ConfigVsiSrcPortTableEntry(ClientInterface& client,
-                                        const struct src_port_info& sp,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry) {
+absl::Status WriteVsiSrcPortTableEntry(ClientInterface& client,
+                                       const struct src_port_info& sp,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -534,7 +535,7 @@ absl::Status ConfigVsiSrcPortTableEntry(ClientInterface& client,
   return client.sendWriteRequest(write_request);
 }
 
-// extracted from ConfigRxTunnelSrcPortTableEntry
+// extracted from WriteRxTunnelSrcPortTableEntry
 void PrepareRxTunnelSrcPortTableEntry(p4::v1::TableEntry* table_entry,
                                       const struct tunnel_info& tunnel_info,
                                       const ::p4::config::v1::P4Info& p4info,
@@ -549,7 +550,7 @@ void PrepareRxTunnelSrcPortTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 // called-by: DoConfigRxTunnelSrcEntry (es2k)
-absl::Status ConfigRxTunnelSrcPortTableEntry(
+absl::Status WriteRxTunnelSrcPortTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -563,7 +564,7 @@ absl::Status ConfigRxTunnelSrcPortTableEntry(
   return client.sendWriteRequest(write_request);
 }
 
-// called-by: ConfigTunnelTermTableEntry
+// called-by: WriteTunnelTermTableEntry
 void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                      const struct tunnel_info& tunnel_info,
                                      const ::p4::config::v1::P4Info& p4info,
@@ -581,10 +582,10 @@ void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 #endif  // ES2K_TARGET
 
 // called-by: DoConfigTunnelEntry (common)
-absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry) {
+absl::Status WriteTunnelTermTableEntry(ClientInterface& client,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -605,10 +606,10 @@ absl::Status ConfigTunnelTermTableEntry(ClientInterface& client,
 #if defined(ES2K_TARGET)
 
 // called-by: DoConfigIpMacMapEntry (es2k)
-absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry) {
+absl::Status WriteDstIpMacMapTableEntry(ClientInterface& client,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -626,10 +627,10 @@ absl::Status ConfigDstIpMacMapTableEntry(ClientInterface& client,
 }
 
 // called-by: DoConfigIpMacMapEntry (es2k)
-absl::Status ConfigSrcIpMacMapTableEntry(ClientInterface& client,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry) {
+absl::Status WriteSrcIpMacMapTableEntry(ClientInterface& client,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -727,13 +728,13 @@ absl::Status ConfigFdbTunnelEntry(ClientInterface& client,
   }
 
   // Ignores status (why?)
-  (void)ConfigFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
 
   // Ignores status (why?)
-  (void)ConfigL2TunnelTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteL2TunnelTableEntry(client, learn_info, p4info, insert_entry);
 
   // Ignores status (why?)
-  (void)ConfigFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
 
   return absl::OkStatus();
 }
@@ -754,17 +755,17 @@ absl::Status ConfigFdbVlanEntry(ClientInterface& client,
     }
 
     // Ignores status (why?)
-    (void)ConfigFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
+    (void)WriteFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
 
     status = ConfigFdbUpdateSrcPort(client, learn_info, p4info);
     if (!status.ok()) return status;
   }
 
   // Ignores status (why?)
-  (void)ConfigFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
 
   // Ignores status (why?)
-  (void)ConfigFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
+  (void)WriteFdbSmacTableEntry(client, learn_info, p4info, insert_entry);
 
   return absl::OkStatus();
 }
@@ -835,8 +836,8 @@ absl::Status DoConfigRxTunnelSrcEntry(ClientInterface& client,
   if (!status.ok()) return status;
 
   // Update P4 tables.
-  return ConfigRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
-                                         insert_entry);
+  return WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
+                                        insert_entry);
 }
 
 //----------------------------------------------------------------------
@@ -844,10 +845,10 @@ absl::Status DoConfigRxTunnelSrcEntry(ClientInterface& client,
 //----------------------------------------------------------------------
 
 // extracted from DoConfigTunnelSrcPortEntry (testable)
-absl::Status ConfigTunnelSrcPortEntry(ClientInterface& client,
-                                      const struct src_port_info& tnl_sp,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+absl::Status WriteTunnelSrcPortEntry(ClientInterface& client,
+                                     const struct src_port_info& tnl_sp,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -874,7 +875,7 @@ absl::Status DoConfigTunnelSrcPortEntry(ClientInterface& client,
   if (!status.ok()) return status;
 
   // Update P4 tables.
-  return ConfigTunnelSrcPortEntry(client, tnl_sp, p4info, insert_entry);
+  return WriteTunnelSrcPortEntry(client, tnl_sp, p4info, insert_entry);
 }
 
 //----------------------------------------------------------------------
@@ -923,7 +924,7 @@ absl::Status ConfigSrcPortEntry(ClientInterface& client,
   vsi_sp.src_port = host_sp;
   // end of refactoring
 
-  return ConfigVsiSrcPortTableEntry(client, vsi_sp, p4info, insert_entry);
+  return WriteVsiSrcPortTableEntry(client, vsi_sp, p4info, insert_entry);
 }
 
 absl::Status DoConfigSrcPortEntry(ClientInterface& client,
@@ -954,10 +955,10 @@ absl::Status ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
                              bool insert_entry) {
   absl::Status status;
 
-  status = ConfigVlanPushTableEntry(client, vlan_id, p4info, insert_entry);
+  status = WriteVlanPushTableEntry(client, vlan_id, p4info, insert_entry);
   if (!status.ok()) return status;
 
-  return ConfigVlanPopTableEntry(client, vlan_id, p4info, insert_entry);
+  return WriteVlanPopTableEntry(client, vlan_id, p4info, insert_entry);
 }
 
 absl::Status DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
@@ -989,13 +990,13 @@ absl::Status ConfigFdbEntry(ClientInterface& client,
                             const ::p4::config::v1::P4Info& p4info,
                             bool insert_entry) {
   if (learn_info.is_tunnel) {
-    return ConfigFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
+    return WriteFdbTunnelTableEntry(client, learn_info, p4info, insert_entry);
   } else if (learn_info.is_vlan) {
     auto status =
-        ConfigFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
+        WriteFdbTxVlanTableEntry(client, learn_info, p4info, insert_entry);
     if (!status.ok()) return status;
 
-    return ConfigFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
+    return WriteFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
   } else {
     // TODO(Derek): return error status?
     return absl::OkStatus();
@@ -1033,15 +1034,15 @@ absl::Status ConfigTunnelEntry(ClientInterface& client,
                                bool insert_entry) {
   absl::Status status;
 
-  status = ConfigEncapTableEntry(client, tunnel_info, p4info, insert_entry);
+  status = WriteEncapTableEntry(client, tunnel_info, p4info, insert_entry);
   if (!status.ok()) return status;
 
 #if defined(ES2K_TARGET)
-  status = ConfigDecapTableEntry(client, tunnel_info, p4info, insert_entry);
+  status = WriteDecapTableEntry(client, tunnel_info, p4info, insert_entry);
   if (!status.ok()) return status;
 #endif
 
-  return ConfigTunnelTermTableEntry(client, tunnel_info, p4info, insert_entry);
+  return WriteTunnelTermTableEntry(client, tunnel_info, p4info, insert_entry);
 }
 
 absl::Status DoConfigTunnelEntry(ClientInterface& client,
@@ -1082,7 +1083,7 @@ absl::Status ConfigIpMacMapEntry(ClientInterface& client,
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
     // Ignores errors (why?)
-    (void)ConfigSrcIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
+    (void)WriteSrcIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
   }
 
 try_dstip:
@@ -1095,7 +1096,7 @@ try_dstip:
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
     // Ignores errors (why?)
-    (void)ConfigDstIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
+    (void)WriteDstIpMacMapTableEntry(client, ip_info, p4info, insert_entry);
   }
   return absl::OkStatus();
 }

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -586,10 +586,10 @@ void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::Status ConfigFdbSmacTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                     const struct mac_learning_info& learn_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+absl::Status WriteFdbSmacTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                    const struct mac_learning_info& learn_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -611,10 +611,10 @@ absl::Status ConfigFdbSmacTableEntry(ovsp4rt::OvsP4rtSession* session,
   return status;
 }
 
-absl::Status ConfigL2TunnelTableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
+absl::Status WriteL2TunnelTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                     const struct mac_learning_info& learn_info,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -642,7 +642,7 @@ absl::Status ConfigL2TunnelTableEntry(
 
 #endif  // ES2K_TARGET
 
-absl::Status ConfigFdbTxVlanTableEntry(
+absl::Status WriteFdbTxVlanTableEntry(
     ovsp4rt::OvsP4rtSession* session,
     const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -667,7 +667,7 @@ absl::Status ConfigFdbTxVlanTableEntry(
   return status;
 }
 
-absl::Status ConfigFdbRxVlanTableEntry(
+absl::Status WriteFdbRxVlanTableEntry(
     ovsp4rt::OvsP4rtSession* session,
     const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -692,7 +692,7 @@ absl::Status ConfigFdbRxVlanTableEntry(
   return status;
 }
 
-absl::Status ConfigFdbTunnelTableEntry(
+absl::Status WriteFdbTunnelTableEntry(
     ovsp4rt::OvsP4rtSession* session,
     const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
@@ -1554,10 +1554,10 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-absl::Status ConfigEncapTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+absl::Status WriteEncapTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -1752,10 +1752,10 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
-absl::Status ConfigDecapTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+absl::Status WriteDecapTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -1835,10 +1835,10 @@ void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::Status ConfigVlanPushTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                      const uint16_t vlan_id,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+absl::Status WriteVlanPushTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                     const uint16_t vlan_id,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -1853,10 +1853,10 @@ absl::Status ConfigVlanPushTableEntry(ovsp4rt::OvsP4rtSession* session,
   return ovsp4rt::SendWriteRequest(session, write_request);
 }
 
-absl::Status ConfigVlanPopTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                     const uint16_t vlan_id,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+absl::Status WriteVlanPopTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                    const uint16_t vlan_id,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -2174,7 +2174,7 @@ absl::Status ConfigureVsiSrcPortTableEntry(
   return ovsp4rt::SendWriteRequest(session, write_request);
 }
 
-absl::Status ConfigRxTunnelSrcPortTableEntry(
+absl::Status WriteRxTunnelSrcPortTableEntry(
     ovsp4rt::OvsP4rtSession* session, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
@@ -2199,10 +2199,10 @@ absl::Status ConfigRxTunnelSrcPortTableEntry(
 
 #endif  // ES2K_TARGET
 
-absl::Status ConfigTunnelTermTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry) {
+absl::Status WriteTunnelTermTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
@@ -2232,10 +2232,10 @@ absl::Status ConfigTunnelTermTableEntry(ovsp4rt::OvsP4rtSession* session,
 
 #if defined(ES2K_TARGET)
 
-absl::Status ConfigDstIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                         struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry) {
+absl::Status WriteDstIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                        struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -2256,10 +2256,10 @@ absl::Status ConfigDstIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
   return status;
 }
 
-absl::Status ConfigSrcIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                         struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry) {
+absl::Status WriteSrcIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
+                                        struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
@@ -2362,20 +2362,20 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
       }
     }
 
-    status = ConfigFdbTunnelTableEntry(session.get(), learn_info, p4info,
-                                       insert_entry);
-    if (!status.ok()) {
-      // Ignore errors (why?)
-    }
-
-    status = ConfigL2TunnelTableEntry(session.get(), learn_info, p4info,
+    status = WriteFdbTunnelTableEntry(session.get(), learn_info, p4info,
                                       insert_entry);
     if (!status.ok()) {
       // Ignore errors (why?)
     }
 
-    status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
+    status = WriteL2TunnelTableEntry(session.get(), learn_info, p4info,
                                      insert_entry);
+    if (!status.ok()) {
+      // Ignore errors (why?)
+    }
+
+    status =
+        WriteFdbSmacTableEntry(session.get(), learn_info, p4info, insert_entry);
     if (!status.ok()) {
       // Ignore errors (why?)
     }
@@ -2388,8 +2388,8 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
         return;
       }
 
-      status = ConfigFdbRxVlanTableEntry(session.get(), learn_info, p4info,
-                                         insert_entry);
+      status = WriteFdbRxVlanTableEntry(session.get(), learn_info, p4info,
+                                        insert_entry);
       if (!status.ok()) {
         // Ignore errors (why?)
       }
@@ -2432,14 +2432,14 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
       // end of refactoring
     }
 
-    status = ConfigFdbTxVlanTableEntry(session.get(), learn_info, p4info,
-                                       insert_entry);
+    status = WriteFdbTxVlanTableEntry(session.get(), learn_info, p4info,
+                                      insert_entry);
     if (!status.ok()) {
       // Ignore errors (why?)
     }
 
-    status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
-                                     insert_entry);
+    status =
+        WriteFdbSmacTableEntry(session.get(), learn_info, p4info, insert_entry);
     if (!status.ok()) {
       // Ignore errors (why?)
     }
@@ -2469,8 +2469,8 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
   ::absl::Status status = GetForwardingPipelineConfig(session.get(), &p4info);
   if (!status.ok()) return;
 
-  status = ConfigRxTunnelSrcPortTableEntry(session.get(), tunnel_info, p4info,
-                                           insert_entry);
+  status = WriteRxTunnelSrcPortTableEntry(session.get(), tunnel_info, p4info,
+                                          insert_entry);
   if (!status.ok()) return;
 }
 
@@ -2602,11 +2602,10 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
   if (!status.ok()) return;
 
   status =
-      ConfigVlanPushTableEntry(session.get(), vlan_id, p4info, insert_entry);
+      WriteVlanPushTableEntry(session.get(), vlan_id, p4info, insert_entry);
   if (!status.ok()) return;
 
-  status =
-      ConfigVlanPopTableEntry(session.get(), vlan_id, p4info, insert_entry);
+  status = WriteVlanPopTableEntry(session.get(), vlan_id, p4info, insert_entry);
   if (!status.ok()) return;
 }
 
@@ -2636,15 +2635,15 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   if (!status.ok()) return;
 
   if (learn_info.is_tunnel) {
-    status = ConfigFdbTunnelTableEntry(session.get(), learn_info, p4info,
-                                       insert_entry);
+    status = WriteFdbTunnelTableEntry(session.get(), learn_info, p4info,
+                                      insert_entry);
   } else if (learn_info.is_vlan) {
-    status = ConfigFdbTxVlanTableEntry(session.get(), learn_info, p4info,
-                                       insert_entry);
+    status = WriteFdbTxVlanTableEntry(session.get(), learn_info, p4info,
+                                      insert_entry);
     if (!status.ok()) return;
 
-    status = ConfigFdbRxVlanTableEntry(session.get(), learn_info, p4info,
-                                       insert_entry);
+    status = WriteFdbRxVlanTableEntry(session.get(), learn_info, p4info,
+                                      insert_entry);
     if (!status.ok()) return;
   }
 }
@@ -2697,17 +2696,17 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   if (!status.ok()) return;
 
   status =
-      ConfigEncapTableEntry(session.get(), tunnel_info, p4info, insert_entry);
+      WriteEncapTableEntry(session.get(), tunnel_info, p4info, insert_entry);
   if (!status.ok()) return;
 
 #if defined(ES2K_TARGET)
   status =
-      ConfigDecapTableEntry(session.get(), tunnel_info, p4info, insert_entry);
+      WriteDecapTableEntry(session.get(), tunnel_info, p4info, insert_entry);
   if (!status.ok()) return;
 #endif
 
-  status = ConfigTunnelTermTableEntry(session.get(), tunnel_info, p4info,
-                                      insert_entry);
+  status = WriteTunnelTermTableEntry(session.get(), tunnel_info, p4info,
+                                     insert_entry);
   if (!status.ok()) return;
 }
 
@@ -2744,8 +2743,8 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
   }
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
-    status = ConfigSrcIpMacMapTableEntry(session.get(), ip_info, p4info,
-                                         insert_entry);
+    status = WriteSrcIpMacMapTableEntry(session.get(), ip_info, p4info,
+                                        insert_entry);
     if (!status.ok()) {
       // Ignore errors (why?)
     }
@@ -2761,8 +2760,8 @@ try_dstip:
   }
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
-    status = ConfigDstIpMacMapTableEntry(session.get(), ip_info, p4info,
-                                         insert_entry);
+    status = WriteDstIpMacMapTableEntry(session.get(), ip_info, p4info,
+                                        insert_entry);
     if (!status.ok()) {
       // Ignore errors (why?)
     }

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -15,41 +15,43 @@
 
 namespace ovsp4rt {
 
-extern absl::Status ConfigEncapTableEntry(
-    ClientInterface& client, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern absl::Status WriteEncapTableEntry(ClientInterface& client,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
 
-extern absl::Status ConfigFdbRxVlanTableEntry(
+extern absl::Status WriteFdbRxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-absl::Status ConfigFdbTunnelTableEntry(
+absl::Status WriteFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigFdbTxVlanTableEntry(
+extern absl::Status WriteFdbTxVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigL2TunnelTableEntry(
+extern absl::Status WriteL2TunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigTunnelTermTableEntry(
+extern absl::Status WriteTunnelTermTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
 #if defined(ES2K_TARGET)
 
-extern absl::Status ConfigDecapTableEntry(
-    ClientInterface& client, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern absl::Status WriteDecapTableEntry(ClientInterface& client,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
 
-extern absl::Status ConfigDstIpMacMapTableEntry(
+extern absl::Status WriteDstIpMacMapTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigFdbSmacTableEntry(
+extern absl::Status WriteFdbSmacTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
@@ -61,27 +63,27 @@ extern void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
                                       struct mac_learning_info& learn_info,
                                       const ::p4::config::v1::P4Info& p4info);
 
-extern absl::Status ConfigRxTunnelSrcPortTableEntry(
+extern absl::Status WriteRxTunnelSrcPortTableEntry(
     ClientInterface& client, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigSrcIpMacMapTableEntry(
+extern absl::Status WriteSrcIpMacMapTableEntry(
     ClientInterface& client, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigTunnelSrcPortEntry(
+extern absl::Status WriteTunnelSrcPortEntry(
     ClientInterface& client, const struct src_port_info& tnl_sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigVlanPopTableEntry(
+extern absl::Status WriteVlanPopTableEntry(
     ClientInterface& client, const uint16_t vlan_id,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigVlanPushTableEntry(
+extern absl::Status WriteVlanPushTableEntry(
     ClientInterface& client, const uint16_t vlan_id,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigVsiSrcPortTableEntry(
+extern absl::Status WriteVsiSrcPortTableEntry(
     ClientInterface& client, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -38,7 +38,7 @@ extern void PrepareFdbTxVlanTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-// extracted from ConfigL2TunnelTableEntry
+// extracted from WriteL2TunnelTableEntry
 extern void PrepareL2TunnelTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,

--- a/ovs-p4rt/sidecar/tests/common/config_encap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_encap_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigEncapTableEntry().
+// Unit test for WriteEncapTableEntry().
 
 // Core functionality is handled by Es2kPrepareEncapTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -43,8 +43,7 @@ TEST_F(ConfigEncapTableEntryTest, configEncapTableEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status =
-      ConfigEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -62,8 +61,7 @@ TEST_F(ConfigEncapTableEntryTest, configEncapTableEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status =
-      ConfigEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteEncapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/common/config_fdb_rx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_fdb_rx_vlan_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbRxVlanTableEntry().
+// Unit test for WriteFdbRxVlanTableEntry().
 
 // Core functionality is handled by PrepareFdbRxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -51,7 +51,7 @@ TEST_F(ConfigFdbRxVlanTableEntryTest, configFdbRxVlanEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -69,7 +69,7 @@ TEST_F(ConfigFdbRxVlanTableEntryTest, configFdbRxVlanEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbRxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/common/config_fdb_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_fdb_tunnel_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbTunnelTableEntry().
+// Unit test for WriteFdbTunnelTableEntry().
 
 // Core functionality is handled by PrepareFdbTableEntryforV4VxlanTunnel()
 // or PrepareFdbTableEntryforV4GeneveTunnel, which are tested separately.
@@ -53,7 +53,7 @@ TEST_F(ConfigFdbTunnelTableEntryTest, configFdbTunnelEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -73,7 +73,7 @@ TEST_F(ConfigFdbTunnelTableEntryTest, configFdbTunnelEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/common/config_fdb_tx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_fdb_tx_vlan_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbTxVlanTableEntry().
+// Unit test for WriteFdbTxVlanTableEntry().
 
 // Core functionality is handled by PrepareFdbTxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -51,7 +51,7 @@ TEST_F(ConfigFdbTxVlanTableEntryTest, configFdbTxVlanEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -69,7 +69,7 @@ TEST_F(ConfigFdbTxVlanTableEntryTest, configFdbTxVlanEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbTxVlanTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/common/config_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_tunnel_term_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigTunnelTermTableEntry (common)
+// Unit test for WriteTunnelTermTableEntry (common)
 
 // Core functionality is handled by PrepareL2ToTunnelV4(),
 // which is tested separately. This is a test of the non-core
@@ -42,7 +42,7 @@ TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+      WriteTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -61,7 +61,7 @@ TEST_F(ConfigTunnelTermEntryTest, configTunnelTermEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+      WriteTunnelTermTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_decap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_decap_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigDecapTableEntry().
+// Unit test for WriteDecapTableEntry().
 
 // Core functionality is handled by Es2kPrepareDecapTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -43,8 +43,7 @@ TEST_F(ConfigDecapTableEntryTest, ConfigDecapTableEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status =
-      ConfigDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -62,8 +61,7 @@ TEST_F(ConfigDecapTableEntryTest, ConfigDecapTableEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status =
-      ConfigDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
+  auto status = WriteDecapTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_fdb_smac_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_fdb_smac_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbSmacTableEntry().
+// Unit test for WriteFdbSmacTableEntry().
 
 // Core functionality is handled by PrepareFdbSmacTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -51,7 +51,7 @@ TEST_F(ConfigFdbSmacTableEntryTest, configFdbSmacEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -69,7 +69,7 @@ TEST_F(ConfigFdbSmacTableEntryTest, configFdbSmacEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteFdbSmacTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_tunnel_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_tunnel_src_port_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigTunnelSrcPortEntry().
+// Unit test for WriteTunnelSrcPortEntry().
 
 #include <absl/status/status.h>
 
@@ -48,7 +48,7 @@ TEST_F(ConfigTunnelSrcPortTest, configTunnelSrcPortFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigTunnelSrcPortEntry(client, port_info, p4info, INSERT_ENTRY);
+      WriteTunnelSrcPortEntry(client, port_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -66,7 +66,7 @@ TEST_F(ConfigTunnelSrcPortTest, configTunnelSrcPortSuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigTunnelSrcPortEntry(client, port_info, p4info, INSERT_ENTRY);
+      WriteTunnelSrcPortEntry(client, port_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_pop_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_pop_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigVlanPopTableEntry().
+// Unit test for WriteVlanPopTableEntry().
 
 // Core functionality is handled by PrepareVlanPopTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -40,7 +40,7 @@ TEST_F(ConfigVlanPopTableEntryTest, configVlanPushEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status = ConfigVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -56,7 +56,7 @@ TEST_F(ConfigVlanPopTableEntryTest, configVlanPushEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status = ConfigVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPopTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_push_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_push_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigVlanPushTableEntry().
+// Unit test for WriteVlanPushTableEntry().
 
 // Core functionality is handled by PrepareVlanPushTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -40,7 +40,7 @@ TEST_F(ConfigVlanPushTableEntryTest, configVlanPushEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status = ConfigVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -56,7 +56,7 @@ TEST_F(ConfigVlanPushTableEntryTest, configVlanPushEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status = ConfigVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
+  auto status = WriteVlanPushTableEntry(client, VLAN_ID, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_vsi_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_vsi_src_port_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigVlanPopTableEntry().
+// Unit test for WriteVlanPopTableEntry().
 
 // Core functionality is handled by PrepareSrcPortTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -49,7 +49,7 @@ TEST_F(ConfigVsiSrcPortEntryTest, configVsiSrcPortEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
+      WriteVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -67,7 +67,7 @@ TEST_F(ConfigVsiSrcPortEntryTest, configVsiSrcPortEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
+      WriteVsiSrcPortTableEntry(client, port_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_dst_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_dst_ip_mac_map_test.cc
@@ -2,7 +2,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigDstIpMacMapTableEntry(). [es2k]
+// Unit test for WriteDstIpMacMapTableEntry(). [es2k]
 
 #include <absl/status/status.h>
 
@@ -40,7 +40,7 @@ TEST_F(Es2kConfigDstIpMacMapTest, configDstIpMacMapWriteFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigDstIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
+      WriteDstIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -58,7 +58,7 @@ TEST_F(Es2kConfigDstIpMacMapTest, configDstIpMacMapWriteSuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigDstIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
+      WriteDstIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_l2_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_l2_tunnel_table_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigL2TunnelTableEntry().
+// Unit test for WriteL2TunnelTableEntry().
 
 // Core functionality is provided by PrepareL2TunnelTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -44,7 +44,7 @@ TEST_F(ConfigL2TunnelTableEntryTest, ConfigL2TunnelTableEntryFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -63,7 +63,7 @@ TEST_F(ConfigL2TunnelTableEntryTest, ConfigL2TunnelTableEntrySuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
+      WriteL2TunnelTableEntry(client, learn_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_rx_tunnel_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_rx_tunnel_port_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigRxTunnelSrcPortTableEntry().
+// Unit test for WriteRxTunnelSrcPortTableEntry().
 
 // Core functionality is handled by PrepareRxTunnelSrcPortTableEntry(),
 // which is tested separately. This is a test of the non-core
@@ -41,7 +41,7 @@ TEST_F(Es2kConfigRxTunnelPortEntryTest, configRxTunnelEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status = ConfigRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
+  auto status = WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
                                                 INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
@@ -60,7 +60,7 @@ TEST_F(Es2kConfigRxTunnelPortEntryTest, configRxTunnelEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status = ConfigRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
+  auto status = WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
                                                 INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_rx_tunnel_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_rx_tunnel_port_entry_test.cc
@@ -41,8 +41,8 @@ TEST_F(Es2kConfigRxTunnelPortEntryTest, configRxTunnelEntryFailure) {
   EXPECT_CALL(client, sendWriteRequest)
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
-  auto status = WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
-                                                INSERT_ENTRY);
+  auto status =
+      WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -60,8 +60,8 @@ TEST_F(Es2kConfigRxTunnelPortEntryTest, configRxTunnelEntrySuccess) {
   TestClientMock client;
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
-  auto status = WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info,
-                                                INSERT_ENTRY);
+  auto status =
+      WriteRxTunnelSrcPortTableEntry(client, tunnel_info, p4info, INSERT_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_src_ip_mac_map_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_config_src_ip_mac_map_test.cc
@@ -2,7 +2,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigSrcIpMacMapTableEntry(). [es2k]
+// Unit test for WriteSrcIpMacMapTableEntry(). [es2k]
 
 #include <absl/status/status.h>
 
@@ -40,7 +40,7 @@ TEST_F(Es2kConfigSrcIpMacMapTest, configSrcIpMacMapWriteFailure) {
       .WillOnce(Return(absl::InternalError(ERROR_MESSAGE)));
 
   auto status =
-      ConfigSrcIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
+      WriteSrcIpMacMapTableEntry(client, map_info, p4info, INSERT_ENTRY);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsInternal(status) && status.message() == ERROR_MESSAGE)
@@ -58,7 +58,7 @@ TEST_F(Es2kConfigSrcIpMacMapTest, configSrcIpMacMapWriteSuccess) {
   EXPECT_CALL(client, sendWriteRequest).WillOnce(Return(absl::OkStatus()));
 
   auto status =
-      ConfigSrcIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
+      WriteSrcIpMacMapTableEntry(client, map_info, p4info, REMOVE_ENTRY);
 
   ASSERT_TRUE(status.ok()) << status;
 }


### PR DESCRIPTION
- Renamed functions whose sole purpose is to encode a protobuf and send it to the server from `Config` to `Write`.

  Included `ovsp4rt.cc` in this change. We still need to be able to build ovsp4rt in legacy mode, and renaming a function doesn't affect its behavior.