### PR TITLE
Fix cmake warning in p4rt-ctl build

### DIFF
--- a/clients/p4rt-ctl/CMakeLists.txt
+++ b/clients/p4rt-ctl/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Build file for p4rt-ctl.
 #
 # Copyright 2022-2023 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache 2.0
 #
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 # Define PYTHON3 variable.
 find_program(PYTHON3 python3)


### PR DESCRIPTION
- Updated `cmake_minimum_required()` VERSION from 3.5 to 3.15, to silence a cmake warning.