### PR TITLE
Set FOUND variables in find-modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(CMakePrintHelpers)
 include(CompilerSettings)
 include(CTest)
 include(ExternalProject)
+#include(FeatureSummary)
 include(FindPkgConfig)
 include(GNUInstallDirs)
 
@@ -188,11 +189,11 @@ mark_as_advanced(OpenSSL_DIR)
 
 # P4 SDE for the target system.
 if(DPDK_TARGET)
-    find_package(DpdkDriver)
+    find_package(DpdkDriver REQUIRED)
 elseif(ES2K_TARGET)
-    find_package(Es2kDriver)
+    find_package(Es2kDriver REQUIRED)
 elseif(TOFINO_TARGET)
-    find_package(TofinoDriver)
+    find_package(TofinoDriver REQUIRED)
 endif()
 
 # Open vSwitch.
@@ -245,3 +246,5 @@ add_subdirectory(stratum)
 add_subdirectory(infrap4d)
 add_subdirectory(clients)
 add_subdirectory(scripts)
+
+#feature_summary(WHAT ALL)

--- a/cmake/FindDpdkDriver.cmake
+++ b/cmake/FindDpdkDriver.cmake
@@ -1,6 +1,7 @@
 # FindDpdkDriver.cmake - import DPDK P4 Driver (SDE).
 #
 # Copyright 2023 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -23,6 +24,8 @@ if(NOT SDE_INCLUDE_DIR)
   message(FATAL_ERROR "DPDK SDE setup failed")
 endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
+
+set(DpdkDriver_FOUND TRUE)
 
 #-----------------------------------------------------------------------
 # Add SDE install directory to search path

--- a/cmake/FindEs2kDriver.cmake
+++ b/cmake/FindEs2kDriver.cmake
@@ -1,6 +1,7 @@
 # FindEs2kDriver.cmake - import ES2K P4 Driver (SDE).
 #
 # Copyright 2023 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -23,6 +24,8 @@ if(NOT SDE_INCLUDE_DIR)
   message(FATAL_ERROR "ES2K SDE setup failed")
 endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
+
+set(Es2kDriver_FOUND TRUE)
 
 #-----------------------------------------------------------------------
 # Add SDE install directory to search path

--- a/cmake/FindHostProtoc.cmake
+++ b/cmake/FindHostProtoc.cmake
@@ -1,6 +1,7 @@
 # Import host Protobuf compiler.
 #
 # Copyright 2022-2023 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -16,6 +17,8 @@ mark_as_advanced(HOST_PROTOC_COMMAND)
 if(NOT HOST_PROTOC_COMMAND)
   message(FATAL_ERROR "protoc not found")
 endif()
+
+set(HostProtoc_FOUND TRUE)
 
 #-----------------------------------------------------------------------
 # Get compiler version number.

--- a/cmake/FindTofinoDriver.cmake
+++ b/cmake/FindTofinoDriver.cmake
@@ -1,6 +1,7 @@
 # FindTofinoDriver.cmake - import Tofino P4 Driver (SDE).
 #
 # Copyright 2023 Intel Corporation
+# Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -23,6 +24,8 @@ if(NOT SDE_INCLUDE_DIR)
   message(FATAL_ERROR "Tofino SDE setup failed")
 endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
+
+set(TofinoDriver_FOUND TRUE)
 
 #-----------------------------------------------------------------------
 # Add SDE install directory to search path


### PR DESCRIPTION
- Modified the `FindDpdkDriver`, `FindEs2kDriver`, `FindTofinoDriver`, and `FindHostProtoc` find-modules to set the appropriate FOUND variable.

- Make the SDE driver packages REQUIRED.