### PR TITLE
Rename protobuf Encode functions

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -42,8 +42,8 @@ absl::Status WriteFdbSmacTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareFdbSmacTableEntry(table_entry, learn_info, p4info, insert_entry,
-                           detail);
+  EncodeFdbSmacTableEntry(table_entry, learn_info, p4info, insert_entry,
+                          detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -60,9 +60,9 @@ void PrepareL2TunnelTableEntry(p4::v1::TableEntry* table_entry,
                                bool insert_entry, DiagDetail& detail) {
   if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
       learn_info.tnl_info.remote_ip.family == AF_INET6) {
-    PrepareL2ToTunnelV6(table_entry, learn_info, p4info, insert_entry, detail);
+    EncodeL2ToTunnelV6(table_entry, learn_info, p4info, insert_entry, detail);
   } else {
-    PrepareL2ToTunnelV4(table_entry, learn_info, p4info, insert_entry, detail);
+    EncodeL2ToTunnelV4(table_entry, learn_info, p4info, insert_entry, detail);
   }
 }
 
@@ -99,8 +99,8 @@ absl::Status WriteFdbTxVlanTableEntry(
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
-                             detail);
+  EncodeFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
+                            detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -120,8 +120,8 @@ absl::Status WriteFdbRxVlanTableEntry(
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
-                             detail);
+  EncodeFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
+                            detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -138,17 +138,17 @@ void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
                                     const ::p4::config::v1::P4Info& p4info,
                                     bool insert_entry, DiagDetail& detail) {
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                         insert_entry, detail);
+    EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                        insert_entry, detail);
   } else if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
-                                          insert_entry, detail);
+    EncodeFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
+                                         insert_entry, detail);
   } else {
     if (!insert_entry) {
       // Tunnel type doesn't matter for delete. So calling one of the functions
       // to prepare the entry
-      PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                           insert_entry, detail);
+      EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                          insert_entry, detail);
     }
   }
 }
@@ -164,8 +164,8 @@ absl::Status WriteFdbTunnelTableEntry(
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
 #if defined(DPDK_TARGET)
-  PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                       insert_entry, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                      insert_entry, detail);
 #elif defined(ES2K_TARGET)
   Es2kPrepareFdbTunnelTableEntry(table_entry, learn_info, p4info, insert_entry,
                                  detail);
@@ -187,13 +187,12 @@ void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
                             const ::p4::config::v1::P4Info& p4info,
                             bool insert_entry) {
 #if defined(DPDK_TARGET)
-  PrepareVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveEncapTableEntry(table_entry, tunnel_info, p4info,
-                                 insert_entry);
+    EncodeGeneveEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -208,11 +207,11 @@ void PrepareV6EncapTableEntry(p4::v1::TableEntry* table_entry,
                               const ::p4::config::v1::P4Info& p4info,
                               bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareV6VxlanEncapTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+    EncodeV6VxlanEncapTableEntry(table_entry, tunnel_info, p4info,
+                                 insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareV6GeneveEncapTableEntry(table_entry, tunnel_info, p4info,
-                                   insert_entry);
+    EncodeV6GeneveEncapTableEntry(table_entry, tunnel_info, p4info,
+                                  insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -224,11 +223,11 @@ void PrepareEncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
                                       const ::p4::config::v1::P4Info& p4info,
                                       bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                          insert_entry);
+    EncodeVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                         insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                           insert_entry);
+    EncodeGeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                          insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -240,11 +239,11 @@ void PrepareV6EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
                                         const ::p4::config::v1::P4Info& p4info,
                                         bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareV6VxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                            insert_entry);
+    EncodeV6VxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                           insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareV6GeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                             insert_entry);
+    EncodeV6GeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                            insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -308,11 +307,11 @@ void PrepareDecapModTableEntry(p4::v1::TableEntry* table_entry,
                                const ::p4::config::v1::P4Info& p4info,
                                bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanDecapModTableEntry(table_entry, tunnel_info, p4info,
-                                   insert_entry);
+    EncodeVxlanDecapModTableEntry(table_entry, tunnel_info, p4info,
+                                  insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveDecapModTableEntry(table_entry, tunnel_info, p4info,
-                                    insert_entry);
+    EncodeGeneveDecapModTableEntry(table_entry, tunnel_info, p4info,
+                                   insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -324,11 +323,11 @@ void PrepareDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
-                                              insert_entry);
+    EncodeVxlanDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
+                                             insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
-                                               insert_entry);
+    EncodeGeneveDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
+                                              insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -372,7 +371,7 @@ absl::Status WriteVlanPushTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareVlanPushTableEntry(table_entry, vlan_id, p4info, insert_entry);
+  EncodeVlanPushTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -387,7 +386,7 @@ absl::Status WriteVlanPopTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareVlanPopTableEntry(table_entry, vlan_id, p4info, insert_entry);
+  EncodeVlanPopTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -401,7 +400,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareL2ToTunnelV4(table_entry, learn_info, p4info, false, detail);
+  EncodeL2ToTunnelV4(table_entry, learn_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -415,7 +414,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareL2ToTunnelV6(table_entry, learn_info, p4info, false, detail);
+  EncodeL2ToTunnelV6(table_entry, learn_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -433,11 +432,11 @@ void PrepareFdbTableV4TunnelEntry(p4::v1::TableEntry* table_entry,
   // The optional 'testing' parameter (which defaults to 'false') allows
   // the unit test to override this behavior.
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                         testing, detail);
+    EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                        testing, detail);
   } else if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
-                                          testing, detail);
+    EncodeFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
+                                         testing, detail);
   }
 }
 
@@ -451,8 +450,8 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
   table_entry = client.initReadRequest(&read_request);
 
 #if defined(DPDK_TARGET)
-  PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
-                                       detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
+                                      detail);
 #elif defined(ES2K_TARGET)
   PrepareFdbTableV4TunnelEntry(table_entry, learn_info, p4info, false, detail);
 #else
@@ -471,7 +470,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, false, detail);
+  EncodeFdbTxVlanTableEntry(table_entry, learn_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -486,7 +485,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
+  EncodeSrcIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -501,7 +500,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
+  EncodeDstIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
   return client.sendReadRequest(read_request);
 }
@@ -515,7 +514,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
 
   table_entry = client.initReadRequest(&read_request);
 
-  PrepareTxAccVsiTableEntry(table_entry, sp, p4info);
+  EncodeTxAccVsiTableEntry(table_entry, sp, p4info);
 
   return client.sendReadRequest(read_request);
 }
@@ -530,7 +529,7 @@ absl::Status WriteVsiSrcPortTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareSrcPortTableEntry(table_entry, sp, p4info, insert_entry);
+  EncodeSrcPortTableEntry(table_entry, sp, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -542,10 +541,10 @@ void PrepareRxTunnelSrcPortTableEntry(p4::v1::TableEntry* table_entry,
                                       bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-    PrepareRxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeRxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-    PrepareV6RxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeV6RxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   }
 }
 
@@ -571,11 +570,11 @@ void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                      bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-    PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-    PrepareV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+    EncodeV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
+                                 insert_entry);
   }
 }
 
@@ -592,7 +591,7 @@ absl::Status WriteTunnelTermTableEntry(ClientInterface& client,
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
 #if defined(DPDK_TARGET)
-  PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
   Es2kPrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info,
                                   insert_entry);
@@ -616,8 +615,8 @@ absl::Status WriteDstIpMacMapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
-                               detail);
+  EncodeDstIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
+                              detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -637,8 +636,8 @@ absl::Status WriteSrcIpMacMapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
-                               detail);
+  EncodeSrcIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
+                              detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {
@@ -854,7 +853,7 @@ absl::Status WriteTunnelSrcPortEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
+  EncodeSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -130,10 +130,10 @@ static inline int32_t ValidIpAddr(uint32_t nw_addr) {
 }
 
 #if defined(ES2K_TARGET)
-void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct mac_learning_info& learn_info,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry, DiagDetail& detail) {
+void EncodeFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
+                             const struct mac_learning_info& learn_info,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_SMAC_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_SMAC_TABLE));
 
@@ -157,10 +157,10 @@ void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_TX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
@@ -244,10 +244,10 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 
-void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_RX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_TABLE));
 
@@ -282,10 +282,10 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
 
 #elif defined(DPDK_TARGET)
 
-void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_RX_WITH_TUNNEL_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE));
 
@@ -317,7 +317,7 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
 #error "ASSERT: Unknown TARGET type!"
 #endif
 
-void PrepareFdbTableEntryforV4VxlanTunnel(
+void EncodeFdbTableEntryforV4VxlanTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
@@ -423,7 +423,7 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
 #ifdef ES2K_TARGET
 
 // Never called when DPDK_TARGET is enabled.
-void PrepareFdbTableEntryforV4GeneveTunnel(
+void EncodeFdbTableEntryforV4GeneveTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
@@ -526,10 +526,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
 #endif
 }
 
-void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
-                         const struct mac_learning_info& learn_info,
-                         const ::p4::config::v1::P4Info& p4info,
-                         bool insert_entry, DiagDetail& detail) {
+void EncodeL2ToTunnelV4(p4::v1::TableEntry* table_entry,
+                        const struct mac_learning_info& learn_info,
+                        const ::p4::config::v1::P4Info& p4info,
+                        bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_TO_TUNNEL_V4_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V4_TABLE));
 
@@ -556,10 +556,10 @@ void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
-                         const struct mac_learning_info& learn_info,
-                         const ::p4::config::v1::P4Info& p4info,
-                         bool insert_entry, DiagDetail& detail) {
+void EncodeL2ToTunnelV6(p4::v1::TableEntry* table_entry,
+                        const struct mac_learning_info& learn_info,
+                        const ::p4::config::v1::P4Info& p4info,
+                        bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_TO_TUNNEL_V6_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V6_TABLE));
 
@@ -600,8 +600,8 @@ absl::Status WriteFdbSmacTableEntry(ovsp4rt::OvsP4rtSession* session,
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareFdbSmacTableEntry(table_entry, learn_info, p4info, insert_entry,
-                           detail);
+  EncodeFdbSmacTableEntry(table_entry, learn_info, p4info, insert_entry,
+                          detail);
 
   auto status = ovsp4rt::SendWriteRequest(session, write_request);
   if (!status.ok()) {
@@ -627,9 +627,9 @@ absl::Status WriteL2TunnelTableEntry(ovsp4rt::OvsP4rtSession* session,
 
   if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
       learn_info.tnl_info.remote_ip.family == AF_INET6) {
-    PrepareL2ToTunnelV6(table_entry, learn_info, p4info, insert_entry, detail);
+    EncodeL2ToTunnelV6(table_entry, learn_info, p4info, insert_entry, detail);
   } else {
-    PrepareL2ToTunnelV4(table_entry, learn_info, p4info, insert_entry, detail);
+    EncodeL2ToTunnelV4(table_entry, learn_info, p4info, insert_entry, detail);
   }
 
   auto status = ovsp4rt::SendWriteRequest(session, write_request);
@@ -656,8 +656,8 @@ absl::Status WriteFdbTxVlanTableEntry(
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
-                             detail);
+  EncodeFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
+                            detail);
 
   auto status = ovsp4rt::SendWriteRequest(session, write_request);
   if (!status.ok()) {
@@ -681,8 +681,8 @@ absl::Status WriteFdbRxVlanTableEntry(
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
-                             detail);
+  EncodeFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
+                            detail);
 
   auto status = ovsp4rt::SendWriteRequest(session, write_request);
   if (!status.ok()) {
@@ -707,21 +707,21 @@ absl::Status WriteFdbTunnelTableEntry(
   }
 
 #if defined(DPDK_TARGET)
-  PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                       insert_entry, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                      insert_entry, detail);
 #elif defined(ES2K_TARGET)
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                         insert_entry, detail);
+    EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                        insert_entry, detail);
   } else if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
-                                          insert_entry, detail);
+    EncodeFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
+                                         insert_entry, detail);
   } else {
     if (!insert_entry) {
       // Tunnel type doesn't matter for delete. So calling one of the functions
       // to prepare the entry
-      PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                           insert_entry, detail);
+      EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
+                                          insert_entry, detail);
     }
   }
 #else
@@ -737,10 +737,10 @@ absl::Status WriteFdbTunnelTableEntry(
 }
 
 /* VXLAN_ENCAP_MOD_TABLE */
-void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -799,10 +799,10 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 /* GENEVE_ENCAP_MOD_TABLE */
-void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct tunnel_info& tunnel_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry) {
+void EncodeGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct tunnel_info& tunnel_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -863,13 +863,12 @@ void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
                             const ::p4::config::v1::P4Info& p4info,
                             bool insert_entry) {
 #if defined(DPDK_TARGET)
-  PrepareVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveEncapTableEntry(table_entry, tunnel_info, p4info,
-                                 insert_entry);
+    EncodeGeneveEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -879,10 +878,10 @@ void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
 #if defined(ES2K_TARGET)
 
 /* VXLAN_ENCAP_V6_MOD_TABLE */
-void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+void EncodeV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_V6_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -938,10 +937,10 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 /* GENEVE_ENCAP_V6_MOD_TABLE */
-void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct tunnel_info& tunnel_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry) {
+void EncodeV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_V6_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -1001,18 +1000,18 @@ void PrepareV6EncapTableEntry(p4::v1::TableEntry* table_entry,
                               const ::p4::config::v1::P4Info& p4info,
                               bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareV6VxlanEncapTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+    EncodeV6VxlanEncapTableEntry(table_entry, tunnel_info, p4info,
+                                 insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareV6GeneveEncapTableEntry(table_entry, tunnel_info, p4info,
-                                   insert_entry);
+    EncodeV6GeneveEncapTableEntry(table_entry, tunnel_info, p4info,
+                                  insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
 }
 
 /* VXLAN_ENCAP_VLAN_POP_MOD_TABLE */
-void PrepareVxlanEncapAndVlanPopTableEntry(
+void EncodeVxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE));
@@ -1074,7 +1073,7 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
 }
 
 /* GENEVE_ENCAP_VLAN_POP_MOD_TABLE */
-void PrepareGeneveEncapAndVlanPopTableEntry(
+void EncodeGeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1141,18 +1140,18 @@ void PrepareEncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
                                       const ::p4::config::v1::P4Info& p4info,
                                       bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                          insert_entry);
+    EncodeVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                         insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                           insert_entry);
+    EncodeGeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                          insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
 }
 
 /* VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE */
-void PrepareV6VxlanEncapAndVlanPopTableEntry(
+void EncodeV6VxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1215,7 +1214,7 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
 }
 
 /* GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE */
-void PrepareV6GeneveEncapAndVlanPopTableEntry(
+void EncodeV6GeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1283,20 +1282,20 @@ void PrepareV6EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
                                         const ::p4::config::v1::P4Info& p4info,
                                         bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareV6VxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                            insert_entry);
+    EncodeV6VxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                           insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareV6GeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                             insert_entry);
+    EncodeV6GeneveEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                            insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
 }
 
-void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                               const struct tunnel_info& tunnel_info,
-                               const ::p4::config::v1::P4Info& p4info,
-                               bool insert_entry) {
+void EncodeRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE));
 
@@ -1329,10 +1328,10 @@ void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE));
 
@@ -1367,10 +1366,10 @@ void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
 
 #endif  // ES2K_TARGET
 
-void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   // match remote ipv4 addr
   auto match1 = table_entry->add_match();
   match1->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
@@ -1480,10 +1479,10 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 #if defined(ES2K_TARGET)
-void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+void EncodeV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, IPV6_TUNNEL_TERM_TABLE));
 
   // TODO(derek): table does not have a bridge_id match field. [es2k]
@@ -1597,10 +1596,10 @@ absl::Status WriteEncapTableEntry(ovsp4rt::OvsP4rtSession* session,
 
 #if defined(ES2K_TARGET)
 
-void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct tunnel_info& tunnel_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry) {
+void EncodeVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_DECAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
@@ -1616,10 +1615,10 @@ void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct tunnel_info& tunnel_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+void EncodeGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
+                                    const struct tunnel_info& tunnel_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_DECAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
@@ -1640,17 +1639,17 @@ void PrepareDecapModTableEntry(p4::v1::TableEntry* table_entry,
                                const ::p4::config::v1::P4Info& p4info,
                                bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanDecapModTableEntry(table_entry, tunnel_info, p4info,
-                                   insert_entry);
+    EncodeVxlanDecapModTableEntry(table_entry, tunnel_info, p4info,
+                                  insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveDecapModTableEntry(table_entry, tunnel_info, p4info,
-                                    insert_entry);
+    EncodeGeneveDecapModTableEntry(table_entry, tunnel_info, p4info,
+                                   insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
 }
 
-void PrepareVxlanDecapModAndVlanPushTableEntry(
+void EncodeVxlanDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1694,7 +1693,7 @@ void PrepareVxlanDecapModAndVlanPushTableEntry(
   }
 }
 
-void PrepareGeneveDecapModAndVlanPushTableEntry(
+void EncodeGeneveDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1742,11 +1741,11 @@ void PrepareDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareVxlanDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
-                                              insert_entry);
+    EncodeVxlanDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
+                                             insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareGeneveDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
-                                               insert_entry);
+    EncodeGeneveDecapModAndVlanPushTableEntry(table_entry, tunnel_info, p4info,
+                                              insert_entry);
   } else {
     std::cout << "ERROR: Unsupported tunnel type" << std::endl;
   }
@@ -1775,10 +1774,10 @@ absl::Status WriteDecapTableEntry(ovsp4rt::OvsP4rtSession* session,
   return ovsp4rt::SendWriteRequest(session, write_request);
 }
 
-void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
-                               const uint16_t vlan_id,
-                               const ::p4::config::v1::P4Info& p4info,
-                               bool insert_entry) {
+void EncodeVlanPushTableEntry(p4::v1::TableEntry* table_entry,
+                              const uint16_t vlan_id,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_PUSH_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VLAN_PUSH_MOD_TABLE,
@@ -1816,10 +1815,10 @@ void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
-                              const uint16_t vlan_id,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry) {
+void EncodeVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                             const uint16_t vlan_id,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_POP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VLAN_POP_MOD_TABLE,
@@ -1848,7 +1847,7 @@ absl::Status WriteVlanPushTableEntry(ovsp4rt::OvsP4rtSession* session,
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareVlanPushTableEntry(table_entry, vlan_id, p4info, insert_entry);
+  EncodeVlanPushTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
   return ovsp4rt::SendWriteRequest(session, write_request);
 }
@@ -1866,15 +1865,15 @@ absl::Status WriteVlanPopTableEntry(ovsp4rt::OvsP4rtSession* session,
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareVlanPopTableEntry(table_entry, vlan_id, p4info, insert_entry);
+  EncodeVlanPopTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
   return ovsp4rt::SendWriteRequest(session, write_request);
 }
 
-void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct src_port_info& sp,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry) {
+void EncodeSrcPortTableEntry(p4::v1::TableEntry* table_entry,
+                             const struct src_port_info& sp,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE));
 
@@ -1911,10 +1910,10 @@ void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct ip_mac_map_info& ip_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry, DiagDetail& detail) {
+void EncodeSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct ip_mac_map_info& ip_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_SRC_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, SRC_IP_MAC_MAP_TABLE));
 
@@ -1960,10 +1959,10 @@ void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct ip_mac_map_info& ip_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry, DiagDetail& detail) {
+void EncodeDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct ip_mac_map_info& ip_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_DST_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, DST_IP_MAC_MAP_TABLE));
 
@@ -2009,8 +2008,8 @@ void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
-                               const ::p4::config::v1::P4Info& p4info) {
+void EncodeTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
+                              const ::p4::config::v1::P4Info& p4info) {
   table_entry->set_table_id(GetTableId(p4info, TX_ACC_VSI_TABLE));
 
   auto match = table_entry->add_match();
@@ -2041,7 +2040,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
 
   table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
 
-  PrepareL2ToTunnelV4(table_entry, learn_info, p4info, false, detail);
+  EncodeL2ToTunnelV4(table_entry, learn_info, p4info, false, detail);
 
   return ovsp4rt::SendReadRequest(session, read_request);
 }
@@ -2056,7 +2055,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
 
   table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
 
-  PrepareL2ToTunnelV6(table_entry, learn_info, p4info, false, detail);
+  EncodeL2ToTunnelV6(table_entry, learn_info, p4info, false, detail);
 
   return ovsp4rt::SendReadRequest(session, read_request);
 }
@@ -2072,15 +2071,15 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
   table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
 
 #if defined(DPDK_TARGET)
-  PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
-                                       detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
+                                      detail);
 #elif defined(ES2K_TARGET)
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
-    PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
-                                         detail);
+    EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
+                                        detail);
   } else if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_GENEVE) {
-    PrepareFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
-                                          false, detail);
+    EncodeFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info, false,
+                                         detail);
   } else {
     return absl::UnknownError("Unsupported tunnel type");
   }
@@ -2106,7 +2105,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
 
   table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
 
-  PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, false, detail);
+  EncodeFdbTxVlanTableEntry(table_entry, learn_info, p4info, false, detail);
 
   auto status = ovsp4rt::SendReadRequest(session, read_request);
   if (status.ok() && adding) {
@@ -2125,7 +2124,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
 
   table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
 
-  PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
+  EncodeSrcIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
   return ovsp4rt::SendReadRequest(session, read_request);
 }
@@ -2139,7 +2138,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
 
   table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
 
-  PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
+  EncodeDstIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
   return ovsp4rt::SendReadRequest(session, read_request);
 }
@@ -2152,7 +2151,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
 
   table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
 
-  PrepareTxAccVsiTableEntry(table_entry, sp, p4info);
+  EncodeTxAccVsiTableEntry(table_entry, sp, p4info);
 
   return ovsp4rt::SendReadRequest(session, read_request);
 }
@@ -2169,7 +2168,7 @@ absl::Status ConfigureVsiSrcPortTableEntry(
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareSrcPortTableEntry(table_entry, sp, p4info, insert_entry);
+  EncodeSrcPortTableEntry(table_entry, sp, p4info, insert_entry);
 
   return ovsp4rt::SendWriteRequest(session, write_request);
 }
@@ -2188,10 +2187,10 @@ absl::Status WriteRxTunnelSrcPortTableEntry(
 
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-    PrepareRxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeRxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-    PrepareV6RxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeV6RxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   }
 
   return ovsp4rt::SendWriteRequest(session, write_request);
@@ -2212,16 +2211,16 @@ absl::Status WriteTunnelTermTableEntry(ovsp4rt::OvsP4rtSession* session,
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 #if defined(DPDK_TARGET)
-  PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
 #elif defined(ES2K_TARGET)
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-    PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-    PrepareV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+    EncodeV6TunnelTermTableEntry(table_entry, tunnel_info, p4info,
+                                 insert_entry);
   }
 #else
 #error "ASSERT: Unknown TARGET type!"
@@ -2246,8 +2245,8 @@ absl::Status WriteDstIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
-                               detail);
+  EncodeDstIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
+                              detail);
 
   auto status = ovsp4rt::SendWriteRequest(session, write_request);
   if (!status.ok()) {
@@ -2270,8 +2269,8 @@ absl::Status WriteSrcIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
     table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
-  PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
-                               detail);
+  EncodeSrcIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
+                              detail);
 
   auto status = ovsp4rt::SendWriteRequest(session, write_request);
   if (!status.ok()) {
@@ -2508,7 +2507,7 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
         ovsp4rt::SetupTableEntryToDelete(session.get(), &write_request);
   }
 
-  PrepareSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
+  EncodeSrcPortTableEntry(table_entry, tnl_sp, p4info, insert_entry);
 
   status = ovsp4rt::SendWriteRequest(session.get(), write_request);
   if (!status.ok()) return;

--- a/ovs-p4rt/sidecar/ovsp4rt_encoders.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_encoders.cc
@@ -120,10 +120,10 @@ int GetMatchFieldId(const ::p4::config::v1::P4Info& p4info,
 }
 
 #if defined(ES2K_TARGET)
-void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct mac_learning_info& learn_info,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry, DiagDetail& detail) {
+void EncodeFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
+                             const struct mac_learning_info& learn_info,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_SMAC_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_SMAC_TABLE));
 
@@ -147,10 +147,10 @@ void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_TX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
@@ -234,10 +234,10 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 
-void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_RX_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_TABLE));
 
@@ -272,10 +272,10 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
 
 #elif defined(DPDK_TARGET)
 
-void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail) {
+void EncodeFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_RX_WITH_TUNNEL_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE));
 
@@ -307,7 +307,7 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
 #error "ASSERT: Unknown TARGET type!"
 #endif
 
-void PrepareFdbTableEntryforV4VxlanTunnel(
+void EncodeFdbTableEntryforV4VxlanTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
@@ -413,7 +413,7 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
 #ifdef ES2K_TARGET
 
 // Never called when DPDK_TARGET is enabled.
-void PrepareFdbTableEntryforV4GeneveTunnel(
+void EncodeFdbTableEntryforV4GeneveTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
@@ -516,10 +516,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
 #endif
 }
 
-void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
-                         const struct mac_learning_info& learn_info,
-                         const ::p4::config::v1::P4Info& p4info,
-                         bool insert_entry, DiagDetail& detail) {
+void EncodeL2ToTunnelV4(p4::v1::TableEntry* table_entry,
+                        const struct mac_learning_info& learn_info,
+                        const ::p4::config::v1::P4Info& p4info,
+                        bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_TO_TUNNEL_V4_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V4_TABLE));
 
@@ -546,10 +546,10 @@ void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
-                         const struct mac_learning_info& learn_info,
-                         const ::p4::config::v1::P4Info& p4info,
-                         bool insert_entry, DiagDetail& detail) {
+void EncodeL2ToTunnelV6(p4::v1::TableEntry* table_entry,
+                        const struct mac_learning_info& learn_info,
+                        const ::p4::config::v1::P4Info& p4info,
+                        bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_TO_TUNNEL_V6_TABLE;
   table_entry->set_table_id(GetTableId(p4info, L2_TO_TUNNEL_V6_TABLE));
 
@@ -580,10 +580,10 @@ void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
 
 /* VXLAN_ENCAP_MOD_TABLE */
 // Ipv4, Tagged, Vxlan
-void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -644,10 +644,10 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 /* GENEVE_ENCAP_MOD_TABLE */
 // Ipv4, Tagged, Geneve
-void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct tunnel_info& tunnel_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry) {
+void EncodeGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct tunnel_info& tunnel_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -704,10 +704,10 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 /* VXLAN_ENCAP_V6_MOD_TABLE */
 // Ipv6, Tagged, Vxlan
-void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+void EncodeV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_V6_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -764,10 +764,10 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 /* GENEVE_ENCAP_V6_MOD_TABLE */
 // Ipv6, Tagged, Geneve
-void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct tunnel_info& tunnel_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry) {
+void EncodeV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_ENCAP_V6_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(
@@ -823,7 +823,7 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 /* VXLAN_ENCAP_VLAN_POP_MOD_TABLE */
-void PrepareVxlanEncapAndVlanPopTableEntry(
+void EncodeVxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE));
@@ -885,7 +885,7 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
 }
 
 /* GENEVE_ENCAP_VLAN_POP_MOD_TABLE */
-void PrepareGeneveEncapAndVlanPopTableEntry(
+void EncodeGeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -949,7 +949,7 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
 
 /* VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE */
 // Ipv6, Untagged, Vxlan
-void PrepareV6VxlanEncapAndVlanPopTableEntry(
+void EncodeV6VxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1013,7 +1013,7 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
 
 /* GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE */
 // Ipv6, Untagged, Geneve
-void PrepareV6GeneveEncapAndVlanPopTableEntry(
+void EncodeV6GeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1076,10 +1076,10 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
   }
 }
 
-void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                               const struct tunnel_info& tunnel_info,
-                               const ::p4::config::v1::P4Info& p4info,
-                               bool insert_entry) {
+void EncodeRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE));
 
@@ -1112,10 +1112,10 @@ void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE));
 
@@ -1150,10 +1150,10 @@ void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
 
 #endif  // ES2K_TARGET
 
-void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                 const struct tunnel_info& tunnel_info,
-                                 const ::p4::config::v1::P4Info& p4info,
-                                 bool insert_entry) {
+void EncodeTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct tunnel_info& tunnel_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry) {
   // match remote ipv4 addr
   auto match1 = table_entry->add_match();
   match1->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
@@ -1264,10 +1264,10 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 
-void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                   const struct tunnel_info& tunnel_info,
-                                   const ::p4::config::v1::P4Info& p4info,
-                                   bool insert_entry) {
+void EncodeV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                  const struct tunnel_info& tunnel_info,
+                                  const ::p4::config::v1::P4Info& p4info,
+                                  bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, IPV6_TUNNEL_TERM_TABLE));
 
   // TODO(derek): table does not have a bridge_id match field. [es2k]
@@ -1338,7 +1338,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 // called-by: PrepareDecapModAndVlanPushTableEntry
-void PrepareVxlanDecapModAndVlanPushTableEntry(
+void EncodeVxlanDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1383,7 +1383,7 @@ void PrepareVxlanDecapModAndVlanPushTableEntry(
 }
 
 // called-by: PrepareDecapModAndVlanPushTableEntry
-void PrepareGeneveDecapModAndVlanPushTableEntry(
+void EncodeGeneveDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   table_entry->set_table_id(
@@ -1427,10 +1427,10 @@ void PrepareGeneveDecapModAndVlanPushTableEntry(
   }
 }
 
-void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
-                               const uint16_t vlan_id,
-                               const ::p4::config::v1::P4Info& p4info,
-                               bool insert_entry) {
+void EncodeVlanPushTableEntry(p4::v1::TableEntry* table_entry,
+                              const uint16_t vlan_id,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_PUSH_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VLAN_PUSH_MOD_TABLE,
@@ -1468,10 +1468,10 @@ void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
-                              const uint16_t vlan_id,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry) {
+void EncodeVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                             const uint16_t vlan_id,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VLAN_POP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VLAN_POP_MOD_TABLE,
@@ -1488,10 +1488,10 @@ void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 // called-by: DoConfigTunnelSrcPortEntry (es2k)
-void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct src_port_info& sp,
-                              const ::p4::config::v1::P4Info& p4info,
-                              bool insert_entry) {
+void EncodeSrcPortTableEntry(p4::v1::TableEntry* table_entry,
+                             const struct src_port_info& sp,
+                             const ::p4::config::v1::P4Info& p4info,
+                             bool insert_entry) {
   table_entry->set_table_id(
       GetTableId(p4info, SOURCE_PORT_TO_BRIDGE_MAP_TABLE));
 
@@ -1528,10 +1528,10 @@ void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct ip_mac_map_info& ip_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry, DiagDetail& detail) {
+void EncodeSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct ip_mac_map_info& ip_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_SRC_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, SRC_IP_MAC_MAP_TABLE));
 
@@ -1577,10 +1577,10 @@ void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct ip_mac_map_info& ip_info,
-                                  const ::p4::config::v1::P4Info& p4info,
-                                  bool insert_entry, DiagDetail& detail) {
+void EncodeDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct ip_mac_map_info& ip_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_DST_IP_MAC_MAP_TABLE;
   table_entry->set_table_id(GetTableId(p4info, DST_IP_MAC_MAP_TABLE));
 
@@ -1626,8 +1626,8 @@ void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
-                               const ::p4::config::v1::P4Info& p4info) {
+void EncodeTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
+                              const ::p4::config::v1::P4Info& p4info) {
   table_entry->set_table_id(GetTableId(p4info, TX_ACC_VSI_TABLE));
 
   auto match = table_entry->add_match();
@@ -1648,10 +1648,10 @@ void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
 #endif
 }
 
-void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct tunnel_info& tunnel_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry) {
+void EncodeVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_DECAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
@@ -1667,10 +1667,10 @@ void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct tunnel_info& tunnel_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+void EncodeGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
+                                    const struct tunnel_info& tunnel_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, GENEVE_DECAP_MOD_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -18,22 +18,22 @@ namespace ovsp4rt {
 // Common functions
 //----------------------------------------------------------------------
 
-extern void PrepareFdbRxVlanTableEntry(
+extern void EncodeFdbRxVlanTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareFdbTableEntryforV4GeneveTunnel(
+extern void EncodeFdbTableEntryforV4GeneveTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareFdbTableEntryforV4VxlanTunnel(
+extern void EncodeFdbTableEntryforV4VxlanTunnel(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareFdbTxVlanTableEntry(
+extern void EncodeFdbTxVlanTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
@@ -44,15 +44,15 @@ extern void PrepareL2TunnelTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry);
+extern void EncodeVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
 
-extern void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry);
+extern void EncodeTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
 
 //----------------------------------------------------------------------
 // ES2K-specific functions
@@ -84,53 +84,53 @@ extern void Es2kPrepareTunnelTermTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry, DiagDetail& detail);
+extern void EncodeDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry, DiagDetail& detail);
 
-extern void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct mac_learning_info& learn_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry, DiagDetail& detail);
+extern void EncodeFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
+                                    const struct mac_learning_info& learn_info,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry, DiagDetail& detail);
 
-extern void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                         const struct ip_mac_map_info& ip_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry, DiagDetail& detail);
+extern void EncodeSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct ip_mac_map_info& ip_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry, DiagDetail& detail);
 
-extern void PrepareL2ToTunnelV4(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail);
+extern void EncodeL2ToTunnelV4(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail);
 
-extern void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info& learn_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry, DiagDetail& detail);
+extern void EncodeL2ToTunnelV6(p4::v1::TableEntry* table_entry,
+                               const struct mac_learning_info& learn_info,
+                               const ::p4::config::v1::P4Info& p4info,
+                               bool insert_entry, DiagDetail& detail);
 
-extern void PrepareGeneveDecapModTableEntry(
+extern void EncodeGeneveDecapModTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareGeneveDecapModAndVlanPushTableEntry(
+extern void EncodeGeneveDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
-                                         const struct tunnel_info& tunnel_info,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         bool insert_entry);
+extern void EncodeGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry);
 
-extern void PrepareGeneveEncapAndVlanPopTableEntry(
+extern void EncodeGeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6GeneveEncapAndVlanPopTableEntry(
+extern void EncodeV6GeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6GeneveEncapTableEntry(
+extern void EncodeV6GeneveEncapTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
@@ -138,58 +138,60 @@ extern void PrepareRxTunnelSrcPortTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                      const struct tunnel_info& tunnel_info,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry);
-
-extern void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                        const struct tunnel_info& tunnel_info,
-                                        const ::p4::config::v1::P4Info& p4info,
-                                        bool insert_entry);
-
-extern void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct src_port_info& sp,
+extern void EncodeRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                     const struct tunnel_info& tunnel_info,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry);
 
-extern void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry,
-                                      uint32_t sp,
-                                      const ::p4::config::v1::P4Info& p4info);
+extern void EncodeV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
 
-extern void PrepareV6TunnelTermTableEntry(
-    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern void EncodeSrcPortTableEntry(p4::v1::TableEntry* table_entry,
+                                    const struct src_port_info& sp,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry);
 
-extern void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+extern void EncodeTxAccVsiTableEntry(p4::v1::TableEntry* table_entry,
+                                     uint32_t sp,
+                                     const ::p4::config::v1::P4Info& p4info);
+
+extern void EncodeV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
+
+extern void EncodeVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                                    const uint16_t vlan_id,
+                                    const ::p4::config::v1::P4Info& p4info,
+                                    bool insert_entry);
+
+extern void EncodeVlanPushTableEntry(p4::v1::TableEntry* table_entry,
                                      const uint16_t vlan_id,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry);
 
-extern void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
-                                      const uint16_t vlan_id,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry);
-
-extern void PrepareVxlanDecapModTableEntry(
+extern void EncodeVxlanDecapModTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareVxlanDecapModAndVlanPushTableEntry(
+extern void EncodeVxlanDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareVxlanEncapAndVlanPopTableEntry(
+extern void EncodeVxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6VxlanEncapAndVlanPopTableEntry(
+extern void EncodeV6VxlanEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern void PrepareV6VxlanEncapTableEntry(
-    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern void EncodeV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                         const struct tunnel_info& tunnel_info,
+                                         const ::p4::config::v1::P4Info& p4info,
+                                         bool insert_entry);
 
 #endif  // ES2K_TARGET
 

--- a/ovs-p4rt/sidecar/tests/common/config_fdb_rx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_fdb_rx_vlan_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteFdbRxVlanTableEntry().
 
-// Core functionality is handled by PrepareFdbRxVlanTableEntry(),
+// Core functionality is handled by EncodeFdbRxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/common/config_fdb_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_fdb_tunnel_table_entry_test.cc
@@ -3,8 +3,8 @@
 
 // Unit test for WriteFdbTunnelTableEntry().
 
-// Core functionality is handled by PrepareFdbTableEntryforV4VxlanTunnel()
-// or PrepareFdbTableEntryforV4GeneveTunnel, which are tested separately.
+// Core functionality is handled by EncodeFdbTableEntryforV4VxlanTunnel()
+// or EncodeFdbTableEntryforV4GeneveTunnel, which are tested separately.
 // This is a test of the non-core functionality.
 
 #include <absl/status/status.h>

--- a/ovs-p4rt/sidecar/tests/common/config_fdb_tx_vlan_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_fdb_tx_vlan_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteFdbTxVlanTableEntry().
 
-// Core functionality is handled by PrepareFdbTxVlanTableEntry(),
+// Core functionality is handled by EncodeFdbTxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/common/config_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/config_tunnel_term_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteTunnelTermTableEntry (common)
 
-// Core functionality is handled by PrepareL2ToTunnelV4(),
+// Core functionality is handled by EncodeL2ToTunnelV4(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbRxVlanTableEntry().
+// Unit test for EncodeFdbRxVlanTableEntry().
 // DPDK version.
 
 #include <stdint.h>
@@ -131,7 +131,7 @@ class DpdkFdbRxVlanTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbRxVlanTableEntry()
+// EncodeFdbRxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(DpdkFdbRxVlanTest, remove_entry) {
@@ -139,8 +139,8 @@ TEST_F(DpdkFdbRxVlanTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert
@@ -156,8 +156,8 @@ TEST_F(DpdkFdbRxVlanTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTxVlanTableEntry().
+// Unit test for EncodeFdbTxVlanTableEntry().
 // DPDK edition.
 
 #include <stdint.h>
@@ -128,7 +128,7 @@ class DpdkFdbTxVlanTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbTxVlanTableEntry()
+// EncodeFdbTxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(DpdkFdbTxVlanTest, remove_entry) {
@@ -136,8 +136,8 @@ TEST_F(DpdkFdbTxVlanTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
 
   // Assert
   CheckDetail();
@@ -152,8 +152,8 @@ TEST_F(DpdkFdbTxVlanTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTableEntryforV4VxlanTunnel().
+// Unit test for EncodeFdbTableEntryforV4VxlanTunnel().
 // DPDK version.
 
 #include <arpa/inet.h>
@@ -171,8 +171,8 @@ TEST_F(DpdkFdbTxVxlanTest, remove_entry) {
   InitFdbInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       REMOVE_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -187,8 +187,8 @@ TEST_F(DpdkFdbTxVxlanTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareTunnelTermTableEntry().
+// Unit test for EncodeTunnelTermTableEntry().
 // DPDK edition.
 
 #define DUMP_JSON
@@ -182,7 +182,7 @@ TEST_F(DpdkTunnelTermTest, vxlan_remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -196,7 +196,7 @@ TEST_F(DpdkTunnelTermTest, vxlan_insert_entry) {
   InitAction();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanEncapTableEntry().
+// Unit test for EncodeVxlanEncapTableEntry().
 // DPDK edition.
 
 #define DUMP_JSON
@@ -189,7 +189,7 @@ TEST_F(DpdkVxlanEncapTest, remove_entry) {
   InitTunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -204,7 +204,7 @@ TEST_F(DpdkVxlanEncapTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_fdb_smac_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_fdb_smac_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteFdbSmacTableEntry().
 
-// Core functionality is handled by PrepareFdbSmacTableEntry(),
+// Core functionality is handled by EncodeFdbSmacTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_pop_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_pop_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteVlanPopTableEntry().
 
-// Core functionality is handled by PrepareVlanPopTableEntry(),
+// Core functionality is handled by EncodeVlanPopTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_push_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_vlan_push_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteVlanPushTableEntry().
 
-// Core functionality is handled by PrepareVlanPushTableEntry(),
+// Core functionality is handled by EncodeVlanPushTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/config_vsi_src_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/config_vsi_src_port_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteVlanPopTableEntry().
 
-// Core functionality is handled by PrepareSrcPortTableEntry(),
+// Core functionality is handled by EncodeSrcPortTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/get_fdb_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/get_fdb_vlan_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetFdbVlanTableEntry().
 
-// Core functionality is handled by PrepareFdbTxVlanTableEntry(),
+// Core functionality is handled by EncodeFdbTxVlanTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/get_l2_to_tunnel_v6_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/get_l2_to_tunnel_v6_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetL2ToTunnelV6TableEntry().
 
-// Core functionality is handled by PrepareL2ToTunnelV6(),
+// Core functionality is handled by EncodeL2ToTunnelV6(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/get_vm_dst_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/get_vm_dst_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetVmDstTableEntry().
 
-// Core functionality is handled by PrepareDstIpMacMapTableEntry(),
+// Core functionality is handled by EncodeDstIpMacMapTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/get_vm_src_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/get_vm_src_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for GetVmSrcTableEntry().
 
-// Core functionality is handled by PrepareSrcIpMacMapTableEntry(),
+// Core functionality is handled by EncodeSrcIpMacMapTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareDstIpMacMapTableEntry().
+// Unit test for EncodeDstIpMacMapTableEntry().
 
 //#define DUMP_JSON
 
@@ -159,8 +159,8 @@ TEST_F(DstIpMacMapTableTest, remove_entry) {
   InitMapInfo();
 
   // Act
-  PrepareDstIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
-                               detail);
+  EncodeDstIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
+                              detail);
   DumpTableEntry();
 
   // Assert
@@ -176,8 +176,8 @@ TEST_F(DstIpMacMapTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareDstIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
-                               detail);
+  EncodeDstIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
+                              detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbRxVlanTableEntry()
+// Unit test for EncodeFdbRxVlanTableEntry()
 
 #include <stdint.h>
 
@@ -143,7 +143,7 @@ class FdbRxVlanEntryTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbRxVlanTableEntry()
+// EncodeFdbRxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(FdbRxVlanEntryTest, remove_entry) {
@@ -151,8 +151,8 @@ TEST_F(FdbRxVlanEntryTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert
@@ -168,8 +168,8 @@ TEST_F(FdbRxVlanEntryTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbSmacTableEntry()
+// Unit test for EncodeFdbSmacTableEntry()
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -125,8 +125,7 @@ TEST_F(FdbSmacEntryTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                           detail);
+  EncodeFdbSmacTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -140,8 +139,7 @@ TEST_F(FdbSmacEntryTest, insert_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                           detail);
+  EncodeFdbSmacTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTableEntryforV4GeneveTunnel().
+// Unit test for EncodeFdbTableEntryforV4GeneveTunnel().
 
 #include <stdint.h>
 
@@ -192,8 +192,8 @@ TEST_F(FdbTxGeneveEntryTest, remove_v4_tagged_entry) {
   InitV4NativeTagged(SET_GENEVE_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        REMOVE_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -208,8 +208,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v4_tagged_entry) {
   InitV4NativeTagged(SET_GENEVE_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -222,8 +222,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v4_untagged_entry) {
   InitV4NativeUntagged(POP_VLAN_SET_GENEVE_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -236,8 +236,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_tagged_entry) {
   InitV6NativeTagged(SET_GENEVE_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -250,8 +250,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_untagged_entry) {
   InitV6NativeUntagged(POP_VLAN_SET_GENEVE_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -267,8 +267,8 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_untagged_entry_20_bit_vni) {
   learn_info.tnl_info.vni = 0xFACED;
 
   // Act
-  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
-                                        INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                       INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbTxVlanTableEntry()
+// Unit test for EncodeFdbTxVlanTableEntry()
 //
 // TODO(derek): port and vlan_ptr parameter values are truncated to
 // 8 bits. Need to fix or document why this is correct.
@@ -205,7 +205,7 @@ class FdbTxVlanEntryTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbTxVlanTableEntry()
+// EncodeFdbTxVlanTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(FdbTxVlanEntryTest, remove_entry) {
@@ -213,8 +213,8 @@ TEST_F(FdbTxVlanEntryTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                            detail);
 
   // Assert
   CheckDetail();
@@ -229,8 +229,8 @@ TEST_F(FdbTxVlanEntryTest, insert_untagged_entry) {
   InitUntagged();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
 
   // Assert
   CheckTableEntry();
@@ -243,8 +243,8 @@ TEST_F(FdbTxVlanEntryTest, insert_tagged_entry) {
   InitTagged();
 
   // Act
-  PrepareFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
+  EncodeFdbTxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                            detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
@@ -193,8 +193,8 @@ TEST_F(FdbTxVxlanEntryTest, remove_v4_tagged_entry) {
   InitV4NativeTagged(SET_VXLAN_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       REMOVE_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      REMOVE_ENTRY, detail);
 
   // Assert
   CheckDetail();
@@ -209,8 +209,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v4_tagged_entry) {
   InitV4NativeTagged(SET_VXLAN_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -223,8 +223,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v4_untagged_entry) {
   InitV4NativeUntagged(POP_VLAN_SET_VXLAN_UNDERLAY_V4);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -237,8 +237,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v6_tagged_entry) {
   InitV6NativeTagged(SET_VXLAN_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();
@@ -251,8 +251,8 @@ TEST_F(FdbTxVxlanEntryTest, insert_v6_untagged_entry) {
   InitV6NativeUntagged(POP_VLAN_SET_VXLAN_UNDERLAY_V6);
 
   // Act
-  PrepareFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
-                                       INSERT_ENTRY, detail);
+  EncodeFdbTableEntryforV4VxlanTunnel(&table_entry, fdb_info, p4info,
+                                      INSERT_ENTRY, detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveDecapModTableEntry()
+// Unit test for EncodeGeneveDecapModTableEntry()
 
 #include <stdint.h>
 
@@ -99,8 +99,8 @@ TEST_F(GeneveDecapModTableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                  REMOVE_ENTRY);
+  EncodeGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                 REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -114,8 +114,8 @@ TEST_F(GeneveDecapModTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                  INSERT_ENTRY);
+  EncodeGeneveDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                 INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveDecapModAndVlanPushTableEntry().
+// Unit test for EncodeGeneveDecapModAndVlanPushTableEntry().
 
 #include <stdint.h>
 
@@ -159,8 +159,8 @@ TEST_F(GeneveDecapModVlanPushTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                             REMOVE_ENTRY);
+  EncodeGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                            REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -174,8 +174,8 @@ TEST_F(GeneveDecapModVlanPushTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                             INSERT_ENTRY);
+  EncodeGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                            INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -189,8 +189,8 @@ TEST_F(GeneveDecapModVlanPushTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                             INSERT_ENTRY);
+  EncodeGeneveDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                            INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveEncapTableEntry().
+// Unit test for EncodeGeneveEncapTableEntry().
 
 #include <stdint.h>
 
@@ -151,7 +151,7 @@ class GeneveEncapV4TableTest : public IpTunnelTest {
 };
 
 //----------------------------------------------------------------------
-// Test PrepareGeneveEncapTableEntry()
+// Test EncodeGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(GeneveEncapV4TableTest, remove_entry) {
@@ -159,7 +159,7 @@ TEST_F(GeneveEncapV4TableTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -174,7 +174,7 @@ TEST_F(GeneveEncapV4TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -191,7 +191,7 @@ TEST_F(GeneveEncapV4TableTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareGeneveEncapAndVlanPopTableEntry().
+// Unit test for EncodeGeneveEncapAndVlanPopTableEntry().
 
 #define DUMP_JSON
 
@@ -168,8 +168,8 @@ TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                         REMOVE_ENTRY);
+  EncodeGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                        REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -184,8 +184,8 @@ TEST_F(GeneveEncapV4VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                         INSERT_ENTRY);
+  EncodeGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                        INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6GeneveEncapTableEntry().
+// Unit test for EncodeV6GeneveEncapTableEntry().
 
 #define DUMP_JSON
 
@@ -174,8 +174,8 @@ TEST_F(GeneveEncapV6TableTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 REMOVE_ENTRY);
+  EncodeV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -190,8 +190,8 @@ TEST_F(GeneveEncapV6TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6GeneveEncapAndVlanPopTableEntry().
+// Unit test for EncodeV6GeneveEncapAndVlanPopTableEntry().
 
 #include <stdint.h>
 
@@ -191,8 +191,8 @@ TEST_F(GeneveEncapV6VlanPopTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                           REMOVE_ENTRY);
+  EncodeV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -206,8 +206,8 @@ TEST_F(GeneveEncapV6VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                           INSERT_ENTRY);
+  EncodeV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -223,8 +223,8 @@ TEST_F(GeneveEncapV6VlanPopTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                           INSERT_ENTRY);
+  EncodeV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareL2ToTunnelV4().
+// Unit test for EncodeL2ToTunnelV4().
 
 #define DUMP_JSON
 
@@ -154,7 +154,7 @@ TEST_F(L2ToV4TunnelTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
+  EncodeL2ToTunnelV4(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
   DumpTableEntry();
 
   // Assert
@@ -170,7 +170,7 @@ TEST_F(L2ToV4TunnelTest, insert_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
+  EncodeL2ToTunnelV4(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareL2ToTunnelV6().
+// Unit test for EncodeL2ToTunnelV6().
 
 #include <iostream>
 #include <string>
@@ -115,7 +115,7 @@ TEST_F(L2ToV6TunnelTest, remove_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
+  EncodeL2ToTunnelV6(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
   DumpTableEntry();
 
   // Assert
@@ -130,7 +130,7 @@ TEST_F(L2ToV6TunnelTest, insert_entry) {
   InitFdbInfo();
 
   // Act
-  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
+  EncodeL2ToTunnelV6(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareRxTunnelTableEntry().
+// Unit test for EncodeRxTunnelTableEntry().
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -134,7 +134,7 @@ class RxTunnelPortV4TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareRxTunnelTableEntry()
+// EncodeRxTunnelTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(RxTunnelPortV4TableTest, remove_entry) {
@@ -142,7 +142,7 @@ TEST_F(RxTunnelPortV4TableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareRxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeRxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -156,7 +156,7 @@ TEST_F(RxTunnelPortV4TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareRxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeRxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6RxTunnelTableEntry().
+// Unit test for EncodeV6RxTunnelTableEntry().
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -166,7 +166,7 @@ class RxTunnelPortV6TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareV6RxTunnelTableEntry()
+// EncodeV6RxTunnelTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(RxTunnelPortV6TableTest, remove_entry) {
@@ -174,7 +174,7 @@ TEST_F(RxTunnelPortV6TableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -188,7 +188,7 @@ TEST_F(RxTunnelPortV6TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeV6RxTunnelTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareSrcIpMacMapTableEntry()
+// Unit test for EncodeSrcIpMacMapTableEntry()
 
 #include <arpa/inet.h>
 #include <stdint.h>
@@ -157,8 +157,8 @@ TEST_F(SrcIpMacMapTableTest, remove_entry) {
   InitMapInfo();
 
   // Act
-  PrepareSrcIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
-                               detail);
+  EncodeSrcIpMacMapTableEntry(&table_entry, map_info, p4info, REMOVE_ENTRY,
+                              detail);
 
   // Assert
   CheckDetail();
@@ -173,8 +173,8 @@ TEST_F(SrcIpMacMapTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareSrcIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
-                               detail);
+  EncodeSrcIpMacMapTableEntry(&table_entry, map_info, p4info, INSERT_ENTRY,
+                              detail);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareSrcPortTableEntry()
+// Unit test for EncodeSrcPortTableEntry()
 
 #define DUMP_JSON
 
@@ -135,7 +135,7 @@ class SrcPortTableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareSrcPortTableEntry()
+// EncodeSrcPortTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(SrcPortTableTest, remove_entry) {
@@ -143,7 +143,7 @@ TEST_F(SrcPortTableTest, remove_entry) {
   InitMapInfo();
 
   // Act
-  PrepareSrcPortTableEntry(&table_entry, port_info, p4info, REMOVE_ENTRY);
+  EncodeSrcPortTableEntry(&table_entry, port_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -157,7 +157,7 @@ TEST_F(SrcPortTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareSrcPortTableEntry(&table_entry, port_info, p4info, INSERT_ENTRY);
+  EncodeSrcPortTableEntry(&table_entry, port_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
@@ -182,7 +182,7 @@ class TunnelTermV4TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareTunnelTermTableEntry() - vxlan
+// EncodeTunnelTermTableEntry() - vxlan
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV4TableTest, vxlan_remove_untagged_entry) {
@@ -191,7 +191,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_remove_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -205,7 +205,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_insert_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -218,7 +218,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_remove_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -232,7 +232,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_insert_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -240,7 +240,7 @@ TEST_F(TunnelTermV4TableTest, vxlan_insert_tagged_entry) {
 }
 
 //----------------------------------------------------------------------
-// PrepareTunnelTermTableEntry() - geneve
+// EncodeTunnelTermTableEntry() - geneve
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV4TableTest, geneve_remove_untagged_entry) {
@@ -249,7 +249,7 @@ TEST_F(TunnelTermV4TableTest, geneve_remove_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -263,7 +263,7 @@ TEST_F(TunnelTermV4TableTest, geneve_insert_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -275,7 +275,7 @@ TEST_F(TunnelTermV4TableTest, geneve_remove_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -289,7 +289,7 @@ TEST_F(TunnelTermV4TableTest, geneve_insert_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -302,7 +302,7 @@ TEST_F(TunnelTermV4TableTest, geneve_insert_untagged_entry_with_20_bit_vni) {
   tunnel_info.vni = 0x95054;
 
   // Act
-  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
@@ -220,7 +220,7 @@ class TunnelTermV6TableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareV6TunnelTermTableEntry() - vxlan
+// EncodeV6TunnelTermTableEntry() - vxlan
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV6TableTest, remove_vxlan_untagged_entry) {
@@ -229,8 +229,7 @@ TEST_F(TunnelTermV6TableTest, remove_vxlan_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -244,8 +243,7 @@ TEST_F(TunnelTermV6TableTest, insert_vxlan_untagged_entry) {
   InitVxlanUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -257,8 +255,7 @@ TEST_F(TunnelTermV6TableTest, remove_vxlan_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -272,15 +269,14 @@ TEST_F(TunnelTermV6TableTest, insert_vxlan_tagged_entry) {
   InitVxlanTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
 }
 
 //----------------------------------------------------------------------
-// PrepareV6TunnelTermTableEntry() - geneve
+// EncodeV6TunnelTermTableEntry() - geneve
 //----------------------------------------------------------------------
 
 TEST_F(TunnelTermV6TableTest, remove_geneve_untagged_entry) {
@@ -289,8 +285,7 @@ TEST_F(TunnelTermV6TableTest, remove_geneve_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -304,8 +299,7 @@ TEST_F(TunnelTermV6TableTest, insert_geneve_untagged_entry) {
   InitGeneveUntagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -317,8 +311,7 @@ TEST_F(TunnelTermV6TableTest, remove_geneve_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -332,8 +325,7 @@ TEST_F(TunnelTermV6TableTest, insert_geneve_tagged_entry) {
   InitGeneveTagged();
 
   // Act
-  PrepareV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6TunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareTxAccVsiTableEntry()
+// Unit test for EncodeTxAccVsiTableEntry()
 
 #include <stdint.h>
 
@@ -84,7 +84,7 @@ TEST_F(TxAccVsiTableTest, sp_8_bits) {
   info_sp = 42;
 
   // Act
-  PrepareTxAccVsiTableEntry(&table_entry, info_sp, p4info);
+  EncodeTxAccVsiTableEntry(&table_entry, info_sp, p4info);
 
   // Assert
   CheckTableEntry();
@@ -99,7 +99,7 @@ TEST_F(TxAccVsiTableTest, sp_11_bits) {
   info_sp = 0x765;
 
   // Act
-  PrepareTxAccVsiTableEntry(&table_entry, info_sp, p4info);
+  EncodeTxAccVsiTableEntry(&table_entry, info_sp, p4info);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVlanPopTableEntry()
+// Unit test for EncodeVlanPopTableEntry()
 
 #include <stdint.h>
 
@@ -93,7 +93,7 @@ TEST_F(VlanPopTableTest, remove_entry) {
   InitVlanInfo();
 
   // Act
-  PrepareVlanPopTableEntry(&table_entry, vlan_id, p4info, REMOVE_ENTRY);
+  EncodeVlanPopTableEntry(&table_entry, vlan_id, p4info, REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -107,7 +107,7 @@ TEST_F(VlanPopTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVlanPopTableEntry(&table_entry, vlan_id, p4info, INSERT_ENTRY);
+  EncodeVlanPopTableEntry(&table_entry, vlan_id, p4info, INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVlanPushTableEntry().
+// Unit test for EncodeVlanPushTableEntry().
 
 #include <stdint.h>
 
@@ -24,14 +24,14 @@ class VlanPushModTableTest : public BaseTableTest {
   void InitAction() { SelectAction("vlan_push"); }
 
   void InitPushInfo() {
-    // These values are hard-coded in PrepareVlanPushTableEntry();
+    // These values are hard-coded in EncodeVlanPushTableEntry();
     constexpr uint16_t PCP = 1;
     constexpr uint16_t DEI = 0;
 
     push_info.pcp = PCP;
     push_info.dei = DEI;
 
-    // PrepareVlanPushTableEntry() encodes the value as a single byte.
+    // EncodeVlanPushTableEntry() encodes the value as a single byte.
     push_info.vlan_id = 0xAC;
   }
 
@@ -120,7 +120,7 @@ class VlanPushModTableTest : public BaseTableTest {
   }
 
   void CheckModBlobPtrMatch(const ::p4::v1::FieldMatch& match) const {
-    // TODO(derek): PrepareVlanPushTableEntry() encodes the mod_blob_ptr
+    // TODO(derek): EncodeVlanPushTableEntry() encodes the mod_blob_ptr
     // value as a single byte, which doesn't make sense. The input is
     // a vlan_id, which is bit<12>. The mod_blob ptr value is bit<24>.
     constexpr int MOD_BLOB_PTR_SIZE = 1;
@@ -163,8 +163,8 @@ TEST_F(VlanPushModTableTest, remove_entry) {
   InitPushInfo();
 
   // Act
-  PrepareVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
-                            REMOVE_ENTRY);
+  EncodeVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
+                           REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -178,8 +178,8 @@ TEST_F(VlanPushModTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
-                            INSERT_ENTRY);
+  EncodeVlanPushTableEntry(&table_entry, push_info.vlan_id, p4info,
+                           INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanDecapModTableEntry().
+// Unit test for EncodeVxlanDecapModTableEntry().
 
 #include <stdint.h>
 
@@ -91,7 +91,7 @@ class VxlanDecapModTableTest : public BaseTableTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareVxlanDecapModTableEntry()
+// EncodeVxlanDecapModTableEntry()
 //----------------------------------------------------------------------
 
 TEST_F(VxlanDecapModTableTest, remove_entry) {
@@ -99,8 +99,8 @@ TEST_F(VxlanDecapModTableTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 REMOVE_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -114,8 +114,8 @@ TEST_F(VxlanDecapModTableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
 
   // Assert
   CheckAction();
@@ -128,8 +128,8 @@ TEST_F(VxlanDecapModTableTest, insert_entry_with_20_bit_vni) {
   tunnel_info.vni = 0x87124;  // 20-bit value
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -144,8 +144,8 @@ TEST_F(VxlanDecapModTableTest, insert_entry_with_24_bit_vni) {
   tunnel_info.vni = 0x871244;  // 24-bit value
 
   // Act
-  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  EncodeVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanDecapModAndVlanPushTableEntry().
+// Unit test for EncodeVxlanDecapModAndVlanPushTableEntry().
 
 #include <stdint.h>
 
@@ -159,8 +159,8 @@ TEST_F(VxlanDecapModVlanPushTest, remove_entry) {
   InitTunnelInfo();
 
   // Act
-  PrepareVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                            REMOVE_ENTRY);
+  EncodeVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                           REMOVE_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -174,8 +174,8 @@ TEST_F(VxlanDecapModVlanPushTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                            INSERT_ENTRY);
+  EncodeVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                           INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();
@@ -189,8 +189,8 @@ TEST_F(VxlanDecapModVlanPushTest, insert_entry_with_24_bit_vni) {
   InitAction();
 
   // Act
-  PrepareVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
-                                            INSERT_ENTRY);
+  EncodeVxlanDecapModAndVlanPushTableEntry(&table_entry, tunnel_info, p4info,
+                                           INSERT_ENTRY);
 
   // Assert
   CheckTableEntry();

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanEncapTableEntry().
+// Unit test for EncodeVxlanEncapTableEntry().
 
 #define DUMP_JSON
 
@@ -168,7 +168,7 @@ TEST_F(VxlanEncapV4TableTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -183,7 +183,7 @@ TEST_F(VxlanEncapV4TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  EncodeVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanEncapAndVlanPopTableEntry().
+// Unit test for EncodeVxlanEncapAndVlanPopTableEntry().
 
 #define DUMP_JSON
 
@@ -168,8 +168,8 @@ TEST_F(VxlanEncapV4VlanPopTest, remove_entry) {
   InitV4TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        REMOVE_ENTRY);
+  EncodeVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                       REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -184,8 +184,8 @@ TEST_F(VxlanEncapV4VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        INSERT_ENTRY);
+  EncodeVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                       INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -200,8 +200,8 @@ TEST_F(VxlanEncapV4VlanPopTest, insert_entry_24_bit_vni) {
   tunnel_info.vni = 0x95054;
 
   // Act
-  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        INSERT_ENTRY);
+  EncodeVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                       INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6VxlanEncapTableEntry().
+// Unit test for EncodeV6VxlanEncapTableEntry().
 
 #define DUMP_JSON
 
@@ -173,8 +173,7 @@ TEST_F(VxlanEncapV6TableTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                REMOVE_ENTRY);
+  EncodeV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -189,8 +188,7 @@ TEST_F(VxlanEncapV6TableTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                INSERT_ENTRY);
+  EncodeV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6VxlanEncapAndVlanPopTableEntry().
+// Unit test for EncodeV6VxlanEncapAndVlanPopTableEntry().
 
 #define DUMP_JSON
 
@@ -173,8 +173,8 @@ TEST_F(VxlanEncapV6VlanPopTest, remove_entry) {
   InitV6TunnelInfo(OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                          REMOVE_ENTRY);
+  EncodeV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                         REMOVE_ENTRY);
   DumpTableEntry();
 
   // Assert
@@ -189,8 +189,8 @@ TEST_F(VxlanEncapV6VlanPopTest, insert_entry) {
   InitAction();
 
   // Act
-  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                          INSERT_ENTRY);
+  EncodeV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                         INSERT_ENTRY);
   DumpTableEntry();
 
   // Assert


### PR DESCRIPTION
- Renamed functions whose purpose is to encode a protobuf to begin with 'Encode' instead of 'Prepare'.

  Included ovsp4rt.cc in this change. We still need to be able to build ovsp4rt in legacy mode, and renaming a function doesn't affect its behavior.