### PR TITLE
Rename ovsp4rt Update functions

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -505,7 +505,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
   return client.sendReadRequest(read_request);
 }
 
-// called-by: DoConfigSrcPortEntry, ConfigFdbUpdateSrcPort
+// called-by: DoConfigSrcPortEntry, UpdateFdbSrcPortInfo
 absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
     ClientInterface& client, uint32_t sp,
     const ::p4::config::v1::P4Info& p4info) {
@@ -651,9 +651,9 @@ absl::Status WriteSrcIpMacMapTableEntry(ClientInterface& client,
 // update learn_info accordingly.
 //
 // called-by: DoConfigFdbEntry (es2k)
-void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
-                               struct mac_learning_info& learn_info,
-                               const ::p4::config::v1::P4Info& p4info) {
+void UpdateFdbTunnelInfo(ClientInterface& client,
+                         struct mac_learning_info& learn_info,
+                         const ::p4::config::v1::P4Info& p4info) {
   // Matching entry in IPv4 tunnel table?
   auto status_or_read_response =
       GetL2ToTunnelV4TableEntry(client, learn_info, p4info);
@@ -676,9 +676,9 @@ void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
 }
 
 // called-by: DoConfigFdbEntry (es2k)
-absl::Status ConfigFdbUpdateSrcPort(ClientInterface& client,
-                                    struct mac_learning_info& learn_info,
-                                    const ::p4::config::v1::P4Info& p4info) {
+absl::Status UpdateFdbSrcPortInfo(ClientInterface& client,
+                                  struct mac_learning_info& learn_info,
+                                  const ::p4::config::v1::P4Info& p4info) {
   auto response_or_status =
       GetTxAccVsiTableEntry(client, learn_info.src_port, p4info);
   if (!response_or_status.ok()) {
@@ -756,7 +756,7 @@ absl::Status ConfigFdbVlanEntry(ClientInterface& client,
     // Ignores status (why?)
     (void)WriteFdbRxVlanTableEntry(client, learn_info, p4info, insert_entry);
 
-    status = ConfigFdbUpdateSrcPort(client, learn_info, p4info);
+    status = UpdateFdbSrcPortInfo(client, learn_info, p4info);
     if (!status.ok()) return status;
   }
 
@@ -787,7 +787,7 @@ absl::Status ConfigFdbEntry(ClientInterface& client,
                             bool insert_entry) {
   if (!insert_entry) {
     // updates learn_info
-    ConfigFdbUpdateTunnelInfo(client, learn_info, p4info);
+    UpdateFdbTunnelInfo(client, learn_info, p4info);
   }
 
   if (learn_info.is_tunnel) {

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -15,6 +15,38 @@
 
 namespace ovsp4rt {
 
+extern absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
+    ClientInterface& client, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool adding = false);
+
+extern absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
+    ClientInterface& client, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool adding = false);
+
+extern absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
+    ClientInterface& client, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info);
+
+extern absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
+    ClientInterface& client, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info);
+
+extern absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
+    ClientInterface& client, const struct ip_mac_map_info& ip_info,
+    const ::p4::config::v1::P4Info& p4info);
+
+extern absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
+    ClientInterface& client, struct ip_mac_map_info ip_info,
+    const ::p4::config::v1::P4Info& p4info);
+
+extern absl::Status UpdateFdbSrcPortInfo(
+    ClientInterface& client, struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info);
+
+extern void UpdateFdbTunnelInfo(ClientInterface& client,
+                                struct mac_learning_info& learn_info,
+                                const ::p4::config::v1::P4Info& p4info);
+
 extern absl::Status WriteEncapTableEntry(ClientInterface& client,
                                          const struct tunnel_info& tunnel_info,
                                          const ::p4::config::v1::P4Info& p4info,
@@ -51,14 +83,6 @@ extern absl::Status WriteFdbSmacTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
-extern absl::Status ConfigFdbUpdateSrcPort(
-    ClientInterface& client, struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info);
-
-extern void ConfigFdbUpdateTunnelInfo(ClientInterface& client,
-                                      struct mac_learning_info& learn_info,
-                                      const ::p4::config::v1::P4Info& p4info);
-
 extern absl::Status WriteL2TunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
@@ -86,30 +110,6 @@ extern absl::Status WriteVlanPushTableEntry(
 extern absl::Status WriteVsiSrcPortTableEntry(
     ClientInterface& client, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
-
-extern absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
-    ClientInterface& client, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool adding = false);
-
-extern absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
-    ClientInterface& client, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool adding = false);
-
-extern absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
-    ClientInterface& client, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info);
-
-extern absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
-    ClientInterface& client, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info);
-
-extern absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
-    ClientInterface& client, const struct ip_mac_map_info& ip_info,
-    const ::p4::config::v1::P4Info& p4info);
-
-extern absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
-    ClientInterface& client, struct ip_mac_map_info ip_info,
-    const ::p4::config::v1::P4Info& p4info);
 
 #endif  // ES2K_TARGET
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/es2k/client/CMakeLists.txt
@@ -19,8 +19,8 @@ define_basic_test(do_config_tunnel_entry_test)
 define_basic_test(do_config_tunnel_src_port_test)
 define_basic_test(do_config_vlan_entry_test)
 
-define_basic_test(es2k_update_src_port_test)
-define_basic_test(es2k_update_tunnel_info_test)
+define_basic_test(update_fdb_src_port_info_test)
+define_basic_test(update_fdb_tunnel_info_test)
 
 #-----------------------------------------------------------------------
 # mac_learn_info tests

--- a/ovs-p4rt/sidecar/tests/es2k/client/update_fdb_src_port_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/update_fdb_src_port_info_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbUpdateSrcPort() [ES2K]
+// Unit test for UpdateFdbSrcPortInfo() [ES2K]
 
 #include <absl/status/status.h>
 
@@ -24,10 +24,10 @@ namespace ovsp4rt {
 
 constexpr int SRC_PORT = 72;
 
-class Es2kUpdateSrcPortTest : public BasicTest {
+class UpdateFdbSrcPortInfoTest : public BasicTest {
  protected:
-  Es2kUpdateSrcPortTest() {}
-  virtual ~Es2kUpdateSrcPortTest() = default;
+  UpdateFdbSrcPortInfoTest() {}
+  virtual ~UpdateFdbSrcPortInfoTest() = default;
 
   void InitLearnInfo(struct mac_learning_info& fdb_info) {
     constexpr uint8_t MAC_ADDR[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
@@ -62,9 +62,9 @@ class Es2kUpdateSrcPortTest : public BasicTest {
 };
 
 /**
- * GetTxAccVsiTableEntry failure path.
+ * UpdateFdbSrcPortInfo failure path.
  */
-TEST_F(Es2kUpdateSrcPortTest, getTxAccVsiEntryFailure) {
+TEST_F(UpdateFdbSrcPortInfoTest, entryNotFoundInTable) {
   constexpr char VSI_LOOKUP_FAILED[] = "Not found in VSI table";
 
   struct mac_learning_info learn_info = {0};
@@ -77,16 +77,16 @@ TEST_F(Es2kUpdateSrcPortTest, getTxAccVsiEntryFailure) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(Return(absl::NotFoundError(VSI_LOOKUP_FAILED)));
 
-  auto status = ConfigFdbUpdateSrcPort(client, learn_info, p4info);
+  auto status = UpdateFdbSrcPortInfo(client, learn_info, p4info);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(IsNotFound(status) && status.message() == VSI_LOOKUP_FAILED);
 }
 
 /**
- * GetTxAccVsiTableEntry success path.
+ * UpdateFdbSrcPortInfo success path.
  */
-TEST_F(Es2kUpdateSrcPortTest, getTxAccVsiEntrySuccess) {
+TEST_F(UpdateFdbSrcPortInfoTest, entryFoundInTable) {
   struct mac_learning_info learn_info = {0};
   InitLearnInfo(learn_info);
 
@@ -97,7 +97,7 @@ TEST_F(Es2kUpdateSrcPortTest, getTxAccVsiEntrySuccess) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(VsiLookupResponse));
 
-  auto status = ConfigFdbUpdateSrcPort(client, learn_info, p4info);
+  auto status = UpdateFdbSrcPortInfo(client, learn_info, p4info);
 
   ASSERT_TRUE(status.ok()) << status;
   ASSERT_EQ(learn_info.src_port, SRC_PORT);

--- a/ovs-p4rt/sidecar/tests/es2k/client/update_fdb_tunnel_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/update_fdb_tunnel_info_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for ConfigFdbUpdateTunnelInfo() [ES2K]
+// Unit test for UpdateFdbTunnelInfo() [ES2K]
 
 #include <absl/status/status.h>
 
@@ -23,10 +23,10 @@ namespace ovsp4rt {
 
 constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
 
-class Es2kUpdateTunnelInfoTest : public BasicTest {
+class UpdateFdbTunnelInfoTest : public BasicTest {
  protected:
-  Es2kUpdateTunnelInfoTest() {}
-  virtual ~Es2kUpdateTunnelInfoTest() = default;
+  UpdateFdbTunnelInfoTest() {}
+  virtual ~UpdateFdbTunnelInfoTest() = default;
 
   // The UUT is called when deleting an entry.
   // The only field required is the mac address.
@@ -46,7 +46,7 @@ class Es2kUpdateTunnelInfoTest : public BasicTest {
 /**
  * Entry is in the IPv4 tunnel table.
  */
-TEST_F(Es2kUpdateTunnelInfoTest, EntryInIpv4TunnelTable) {
+TEST_F(UpdateFdbTunnelInfoTest, entryInIpv4TunnelTable) {
   struct mac_learning_info learn_info = {0};
   InitLearnInfo(learn_info);
 
@@ -57,7 +57,7 @@ TEST_F(Es2kUpdateTunnelInfoTest, EntryInIpv4TunnelTable) {
   EXPECT_CALL(client, sendReadRequest)
       .WillOnce(InvokeWithoutArgs(ReturnReadResponse));
 
-  ConfigFdbUpdateTunnelInfo(client, learn_info, expected_p4info);
+  UpdateFdbTunnelInfo(client, learn_info, expected_p4info);
 
   ASSERT_TRUE(learn_info.is_tunnel);
 }
@@ -65,7 +65,7 @@ TEST_F(Es2kUpdateTunnelInfoTest, EntryInIpv4TunnelTable) {
 /**
  * Entry is in the IPv6 tunnel table.
  */
-TEST_F(Es2kUpdateTunnelInfoTest, EntryInIpv6TunnelTable) {
+TEST_F(UpdateFdbTunnelInfoTest, entryInIpv6TunnelTable) {
   struct mac_learning_info learn_info = {0};
   InitLearnInfo(learn_info);
 
@@ -77,7 +77,7 @@ TEST_F(Es2kUpdateTunnelInfoTest, EntryInIpv6TunnelTable) {
       .WillOnce(Return(absl::NotFoundError("not in IPv4 tunnel table")))
       .WillOnce(InvokeWithoutArgs(ReturnReadResponse));
 
-  ConfigFdbUpdateTunnelInfo(client, learn_info, expected_p4info);
+  UpdateFdbTunnelInfo(client, learn_info, expected_p4info);
 
   ASSERT_TRUE(learn_info.is_tunnel);
 }
@@ -85,7 +85,7 @@ TEST_F(Es2kUpdateTunnelInfoTest, EntryInIpv6TunnelTable) {
 /**
  * Entry is not in either tunnel table.
  */
-TEST_F(Es2kUpdateTunnelInfoTest, EntryNotInTunnelTables) {
+TEST_F(UpdateFdbTunnelInfoTest, entryNotInTunnelTables) {
   struct mac_learning_info learn_info = {0};
   InitLearnInfo(learn_info);
 
@@ -97,7 +97,7 @@ TEST_F(Es2kUpdateTunnelInfoTest, EntryNotInTunnelTables) {
       .WillOnce(Return(absl::NotFoundError("not in IPv4 tunnel table")))
       .WillOnce(Return(absl::NotFoundError("not in IPv6 tunnel table")));
 
-  ConfigFdbUpdateTunnelInfo(client, learn_info, expected_p4info);
+  UpdateFdbTunnelInfo(client, learn_info, expected_p4info);
 
   ASSERT_FALSE(learn_info.is_tunnel);
 }


### PR DESCRIPTION
- Renamed ovsp4rt functions that update the input parameter, and their unit tests, to begin with 'Update'.
- Alphabetized function prototypes in 'ovsp4rt_config_int.h'.