### PR TITLE
Implement EncodeL2FwdTxTablePrologue

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -143,13 +143,9 @@ void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
   } else if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_GENEVE) {
     EncodeFdbTableEntryforV4GeneveTunnel(table_entry, learn_info, p4info,
                                          insert_entry, detail);
-  } else {
-    if (!insert_entry) {
-      // Tunnel type doesn't matter for delete. So calling one of the functions
-      // to prepare the entry
-      EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
-                                          insert_entry, detail);
-    }
+  } else if (!insert_entry) {
+    // Just specify the prologue when deleting an entry.
+    EncodeL2FwdTxTablePrologue(table_entry, learn_info, p4info);
   }
 }
 #endif  // ES2K_TARGET

--- a/ovs-p4rt/sidecar/ovsp4rt_encoders.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_encoders.cc
@@ -147,28 +147,38 @@ void EncodeFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
+void EncodeL2FwdTxTablePrologue(p4::v1::TableEntry* table_entry,
+                                const struct mac_learning_info& learn_info,
+                                const ::p4::config::v1::P4Info& p4info) {
+  table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
+  {
+    // match-key: dst_mac
+    auto match = table_entry->add_match();
+    match->set_field_id(
+        GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
+    std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
+    match->mutable_exact()->set_value(mac_addr);
+  }
+#if defined(ES2K_TARGET)
+  {
+    // match-key: bridge_id
+    auto match = table_entry->add_match();
+    match->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
+                                        L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
+    match->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
+  }
+#endif
+}
+
 void EncodeFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
                                const struct mac_learning_info& learn_info,
                                const ::p4::config::v1::P4Info& p4info,
                                bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_TX_TABLE;
-  table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
-
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
+  EncodeL2FwdTxTablePrologue(table_entry, learn_info, p4info);
 
 #if defined(ES2K_TARGET)
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
-
   if (insert_entry) {
     /* Action param configured by user in TX_ACC_VSI_TABLE is used as port_id
      * We call GET api to fetch this value and pass it to FDB programming.
@@ -247,11 +257,9 @@ void EncodeFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
   std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
   match->mutable_exact()->set_value(mac_addr);
 
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
   auto match1 = table_entry->add_match();
   match1->set_field_id(
       GetMatchFieldId(p4info, L2_FWD_RX_TABLE, L2_FWD_RX_TABLE_KEY_BRIDGE_ID));
-
   match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
 
   if (insert_entry) {
@@ -312,21 +320,8 @@ void EncodeFdbTableEntryforV4VxlanTunnel(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_TX_TABLE;
-  table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
-
-#if defined(ES2K_TARGET)
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
-#endif
+  EncodeL2FwdTxTablePrologue(table_entry, learn_info, p4info);
 
 #if defined(DPDK_TARGET)
   if (insert_entry) {
@@ -360,6 +355,7 @@ void EncodeFdbTableEntryforV4VxlanTunnel(
     if (learn_info.tnl_info.local_ip.family == AF_INET &&
         learn_info.tnl_info.remote_ip.family == AF_INET) {
       if (learn_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
+        // IPv4, untagged vlan
         action->set_action_id(GetActionId(
             p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_VXLAN_UNDERLAY_V4));
         {
@@ -370,6 +366,7 @@ void EncodeFdbTableEntryforV4VxlanTunnel(
           param->set_value(EncodeTunnelId(learn_info.tnl_info.vni));
         }
       } else {
+        // IPv4, tagged vlan
         action->set_action_id(
             GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_SET_VXLAN_UNDERLAY_V4));
         {
@@ -383,6 +380,7 @@ void EncodeFdbTableEntryforV4VxlanTunnel(
     } else if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
                learn_info.tnl_info.remote_ip.family == AF_INET6) {
       if (learn_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
+        // IPv6, untagged vlan
         action->set_action_id(GetActionId(
             p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_VXLAN_UNDERLAY_V6));
         {
@@ -393,6 +391,7 @@ void EncodeFdbTableEntryforV4VxlanTunnel(
           param->set_value(EncodeTunnelId(learn_info.tnl_info.vni));
         }
       } else {
+        // IPv6, tagged vlan
         action->set_action_id(
             GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_SET_VXLAN_UNDERLAY_V6));
         {
@@ -418,22 +417,8 @@ void EncodeFdbTableEntryforV4GeneveTunnel(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail) {
   detail.table_id = LOG_L2_FWD_TX_TABLE;
-  table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
 
-  auto match = table_entry->add_match();
-  match->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
-
-  std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
-  match->mutable_exact()->set_value(mac_addr);
-
-#if defined(ES2K_TARGET)
-  // Based on p4 program for ES2K, we need to provide a match key Bridge ID
-  auto match1 = table_entry->add_match();
-  match1->set_field_id(
-      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_BRIDGE_ID));
-  match1->mutable_exact()->set_value(EncodeByteValue(1, learn_info.bridge_id));
-#endif
+  EncodeL2FwdTxTablePrologue(table_entry, learn_info, p4info);
 
 #if defined(DPDK_TARGET)
   if (insert_entry) {
@@ -466,6 +451,7 @@ void EncodeFdbTableEntryforV4GeneveTunnel(
     if (learn_info.tnl_info.local_ip.family == AF_INET &&
         learn_info.tnl_info.remote_ip.family == AF_INET) {
       if (learn_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
+        // IPv4, untagged vlan
         action->set_action_id(GetActionId(
             p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_GENEVE_UNDERLAY_V4));
         {
@@ -476,6 +462,7 @@ void EncodeFdbTableEntryforV4GeneveTunnel(
           param->set_value(EncodeTunnelId(learn_info.tnl_info.vni));
         }
       } else {
+        // IPv4, tagged vlan
         action->set_action_id(
             GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_SET_GENEVE_UNDERLAY_V4));
         {
@@ -489,6 +476,7 @@ void EncodeFdbTableEntryforV4GeneveTunnel(
     } else if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
                learn_info.tnl_info.remote_ip.family == AF_INET6) {
       if (learn_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
+        // IPv6, untagged vlan
         action->set_action_id(GetActionId(
             p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_GENEVE_UNDERLAY_V6));
         {
@@ -499,6 +487,7 @@ void EncodeFdbTableEntryforV4GeneveTunnel(
           param->set_value(EncodeTunnelId(learn_info.tnl_info.vni));
         }
       } else {
+        // IPv6, tagged vlan
         action->set_action_id(
             GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_SET_GENEVE_UNDERLAY_V6));
         {

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -38,6 +38,10 @@ extern void EncodeFdbTxVlanTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
+extern void EncodeL2FwdTxTablePrologue(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info);
+
 // extracted from WriteL2TunnelTableEntry
 extern void PrepareL2TunnelTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,

--- a/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
@@ -76,7 +76,7 @@ macro(define_es2k_tunnel_test TARGET)
 endmacro(define_es2k_tunnel_test)
 
 #-----------------------------------------------------------------------
-# ES2K PrepareTableEntry unit tests
+# ES2K EncodeTableEntry unit tests
 #-----------------------------------------------------------------------
 define_es2k_test(fdb_rx_vlan_entry_test)
 define_es2k_test(fdb_smac_entry_test)
@@ -95,6 +95,7 @@ define_es2k_tunnel_test(geneve_encap_v6_vlan_pop_test)
 define_es2k_test(src_ip_mac_map_table_test)
 define_es2k_test(dst_ip_mac_map_table_test)
 
+define_es2k_test(l2_fwd_tx_prologue_test)
 define_es2k_test(l2_to_v4_tunnel_test)
 define_es2k_test(l2_to_v6_tunnel_test)
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
@@ -52,9 +52,13 @@ class Es2kPrepFdbTunnelTableTest : public BaseMacLearnInfoTest {
     auto action = table_action.action();
     EXPECT_EQ(action.action_id(), expected_action_id);
   }
+
+  static void CheckRemoveAction(const ::p4::v1::TableEntry& table_entry) {
+    EXPECT_FALSE(table_entry.has_action());
+  }
 };
 
-TEST_F(Es2kPrepFdbTunnelTableTest, configV4VxlanTunnelEntry) {
+TEST_F(Es2kPrepFdbTunnelTableTest, insertV4VxlanTunnelEntry) {
   ::p4::v1::TableEntry table_entry;
   DiagDetail detail;
 
@@ -68,11 +72,10 @@ TEST_F(Es2kPrepFdbTunnelTableTest, configV4VxlanTunnelEntry) {
   Es2kPrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, INSERT_ENTRY,
                                  detail);
 
-  // ASSERT
   CheckActionId(table_entry, p4info, OVS_TUNNEL_VXLAN);
 }
 
-TEST_F(Es2kPrepFdbTunnelTableTest, configV4GeneveTunnelEntry) {
+TEST_F(Es2kPrepFdbTunnelTableTest, insertV4GeneveTunnelEntry) {
   ::p4::v1::TableEntry table_entry;
   DiagDetail detail;
 
@@ -87,6 +90,22 @@ TEST_F(Es2kPrepFdbTunnelTableTest, configV4GeneveTunnelEntry) {
                                  detail);
 
   CheckActionId(table_entry, p4info, OVS_TUNNEL_GENEVE);
+}
+
+TEST_F(Es2kPrepFdbTunnelTableTest, removeV4TunnelEntry) {
+  ::p4::v1::TableEntry table_entry;
+  DiagDetail detail;
+
+  struct mac_learning_info learn_info = {0};
+  InitTunnelLearnInfo(learn_info, OVS_TUNNEL_UNKNOWN);
+
+  ::p4::config::v1::P4Info p4info;
+  InitP4Info(&p4info);
+
+  Es2kPrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, REMOVE_ENTRY,
+                                 detail);
+
+  CheckRemoveAction(table_entry);
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/l2_fwd_tx_prologue_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_fwd_tx_prologue_test.cc
@@ -1,0 +1,119 @@
+// Copyright 2024 Intel Corporation
+// Copyright 2025 Derek Foster
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for EncodeL2FwdTxTablePrologue()
+
+#include <stdint.h>
+
+#include <iostream>
+#include <string>
+
+#include "base_table_test.h"
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_private.h"
+
+namespace ovsp4rt {
+
+class L2FwdTxPrologueTest : public BaseTableTest {
+ protected:
+  L2FwdTxPrologueTest() {}
+
+  void SetUp() { SelectTable("l2_fwd_tx_table"); }
+
+  //----------------------------
+  // Initialization
+  //----------------------------
+
+  void InitFdbInfo() {
+    constexpr uint8_t MAC_ADDR[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    constexpr uint8_t BRIDGE_ID = 86;
+
+    memcpy(fdb_info.mac_addr, MAC_ADDR, sizeof(fdb_info.mac_addr));
+    fdb_info.bridge_id = BRIDGE_ID;
+  }
+
+  //----------------------------
+  // CheckMatches()
+  //----------------------------
+
+  void CheckMatches() const {
+    constexpr char BRIDGE_ID_KEY[] = "user_meta.pmeta.bridge_id";
+    constexpr char DST_MAC_KEY[] = "dst_mac";
+
+    const int MFID_BRIDGE_ID = GetMatchFieldId(BRIDGE_ID_KEY);
+    const int MFID_DST_MAC = GetMatchFieldId(DST_MAC_KEY);
+
+    // number of match fields
+    ASSERT_EQ(table_entry.match_size(), 2);
+
+    for (const auto& match : table_entry.match()) {
+      auto field_id = match.field_id();
+      if (field_id == MFID_DST_MAC) {
+        CheckMacAddrMatch(match);
+      } else if (field_id == MFID_BRIDGE_ID) {
+        CheckBridgeIdMatch(match);
+      } else {
+        FAIL() << "Unexpected field_id (" << field_id << ")";
+      }
+    }
+  }
+
+  void CheckMacAddrMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int MAC_ADDR_SIZE = 6;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+    ASSERT_EQ(match_value.size(), MAC_ADDR_SIZE);
+
+    for (int i = 0; i < MAC_ADDR_SIZE; i++) {
+      EXPECT_EQ(match_value[i], fdb_info.mac_addr[i])
+          << "mac_addr[" << i << "] is incorrect";
+    }
+  }
+
+  void CheckBridgeIdMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int BRIDGE_ID_SIZE = 1;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+    ASSERT_EQ(match_value.size(), BRIDGE_ID_SIZE);
+
+    // widen so values will be treated as ints
+    ASSERT_EQ(uint32_t(match_value[0]), uint32_t(fdb_info.bridge_id));
+  }
+
+  //----------------------------
+  // CheckTableEntry()
+  //----------------------------
+
+  void CheckTableEntry() const {
+    ASSERT_TRUE(HasTable());
+    EXPECT_EQ(table_entry.table_id(), TableId());
+  }
+
+  //----------------------------
+  // Protected member data
+  //----------------------------
+
+  struct mac_learning_info fdb_info = {0};
+};
+
+//----------------------------------------------------------------------
+// EncodeL2FwdTxTablePrologue()
+//----------------------------------------------------------------------
+
+TEST_F(L2FwdTxPrologueTest, encodePrologue) {
+  // Arrange
+  InitFdbInfo();
+
+  // Act
+  EncodeL2FwdTxTablePrologue(&table_entry, fdb_info, p4info);
+
+  // Assert
+  CheckTableEntry();
+  CheckMatches();
+}
+
+}  // namespace ovsp4rt


### PR DESCRIPTION
- Extracted EncodeL2FwdTxTablePrologue() function to encode the common L2_FWD_TX_TABLE prologue.

- Modified existing encoders to use extracted function.

- Modified Es2kPrepareFdbTunnelTableEntry() to use the extracted function in the remove_entry case.

- Implemented L2FwdTxPrologueTest unit test.

- Added remove_entry test case to Es2kPrepFdbTunnelTableTest.