### PR TITLE
Rename ovsp4rt_private.h to ovsp4rt_encoders.h

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -33,20 +33,19 @@ endif()
 add_library(ovs_sidecar_o OBJECT
     ${CLIENT_SOURCES}
     ${OVSP4RT_INCLUDE_DIR}/ovsp4rt/ovs-p4rt.h
-    ovsp4rt_private.h
+    ovsp4rt_config_int.h
+    ovsp4rt_encoders.h
 )
 
 if(BUILD_CLIENT)
   if(BUILD_JOURNAL)
     target_sources(ovs_sidecar_o PRIVATE
-      ovsp4rt_config_int.h
       ovsp4rt_do_config_int.h
       ovsp4rt_journal_api.cc
       ovsp4rt_simple_api.cc
     )
   else()
     target_sources(ovs_sidecar_o PRIVATE
-      ovsp4rt_config_int.h
       ovsp4rt_do_config_int.h
       ovsp4rt_simple_api.cc
       ovsp4rt_standard_api.cc

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -14,7 +14,7 @@
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 #include "ovsp4rt_do_config_int.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 #include "ovsp4rt_util_int.h"
 
 #if defined(DPDK_TARGET)

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -11,7 +11,7 @@
 #include "logging/ovsp4rt_logging.h"
 #include "logging/ovsp4rt_logutils.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 #include "session/ovsp4rt_credentials.h"
 #include "session/ovsp4rt_session.h"
 

--- a/ovs-p4rt/sidecar/ovsp4rt_config_int.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_config_int.h
@@ -9,11 +9,57 @@
 #include <absl/status/statusor.h>
 
 #include "client/ovsp4rt_client_interface.h"
+#include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 
 namespace ovsp4rt {
+
+//----------------------------------------------------------------------
+// Prepare functions
+//----------------------------------------------------------------------
+
+extern void PrepareL2TunnelTableEntry(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
+    DiagDetail& detail);
+
+#if defined(ES2K_TARGET)
+
+extern void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
+
+extern void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
+                                       const struct tunnel_info& tunnel_info,
+                                       const ::p4::config::v1::P4Info& p4info,
+                                       bool insert_entry);
+
+extern void PrepareFdbTableV4TunnelEntry(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
+    DiagDetail& detail, bool testing = false);
+
+extern void Es2kPrepareFdbTunnelTableEntry(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
+    DiagDetail& detail);
+
+extern void Es2kPrepareTunnelTermTableEntry(
+    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern void PrepareRxTunnelSrcPortTableEntry(
+    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+#endif  // ES2K_TARGET
+
+//----------------------------------------------------------------------
+// Read functions
+//----------------------------------------------------------------------
 
 extern absl::StatusOr<::p4::v1::ReadResponse> ReadFdbTunnelTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
@@ -22,6 +68,8 @@ extern absl::StatusOr<::p4::v1::ReadResponse> ReadFdbTunnelTableEntry(
 extern absl::StatusOr<::p4::v1::ReadResponse> ReadFdbVlanTableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false);
+
+#if defined(ES2K_TARGET)
 
 extern absl::StatusOr<::p4::v1::ReadResponse> ReadL2ToTunnelV4TableEntry(
     ClientInterface& client, const struct mac_learning_info& learn_info,
@@ -39,6 +87,14 @@ extern absl::StatusOr<::p4::v1::ReadResponse> ReadVmSrcTableEntry(
     ClientInterface& client, struct ip_mac_map_info ip_info,
     const ::p4::config::v1::P4Info& p4info);
 
+#endif  // ES2K_TARGET
+
+//----------------------------------------------------------------------
+// Update functions
+//----------------------------------------------------------------------
+
+#if defined(ES2K_TARGET)
+
 extern absl::Status UpdateFdbSrcPortInfo(
     ClientInterface& client, struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info);
@@ -46,6 +102,12 @@ extern absl::Status UpdateFdbSrcPortInfo(
 extern void UpdateFdbTunnelInfo(ClientInterface& client,
                                 struct mac_learning_info& learn_info,
                                 const ::p4::config::v1::P4Info& p4info);
+
+#endif  // ES2K_TARGET
+
+//----------------------------------------------------------------------
+// Write functions
+//----------------------------------------------------------------------
 
 extern absl::Status WriteEncapTableEntry(ClientInterface& client,
                                          const struct tunnel_info& tunnel_info,

--- a/ovs-p4rt/sidecar/ovsp4rt_encoders.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_encoders.cc
@@ -2,6 +2,8 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ovsp4rt_encoders.h"
+
 #include <arpa/inet.h>
 #include <stdint.h>
 
@@ -9,7 +11,6 @@
 
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
 #include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"

--- a/ovs-p4rt/sidecar/ovsp4rt_encoders.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_encoders.h
@@ -2,8 +2,8 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OVSP4RT_PRIVATE_H_
-#define OVSP4RT_PRIVATE_H_
+#ifndef OVSP4RT_ENCODERS_H_
+#define OVSP4RT_ENCODERS_H_
 
 #include <absl/status/status.h>
 
@@ -15,7 +15,7 @@
 namespace ovsp4rt {
 
 //----------------------------------------------------------------------
-// Common functions
+// Common Encode functions
 //----------------------------------------------------------------------
 
 extern void EncodeFdbRxVlanTableEntry(
@@ -42,12 +42,6 @@ extern void EncodeL2FwdTxTablePrologue(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info);
 
-// extracted from WriteL2TunnelTableEntry
-extern void PrepareL2TunnelTableEntry(
-    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
-    DiagDetail& detail);
-
 extern void EncodeVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
                                        const struct tunnel_info& tunnel_info,
                                        const ::p4::config::v1::P4Info& p4info,
@@ -59,34 +53,10 @@ extern void EncodeTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
                                        bool insert_entry);
 
 //----------------------------------------------------------------------
-// ES2K-specific functions
+// ES2K-specific Encode functions
 //----------------------------------------------------------------------
 
 #if defined(ES2K_TARGET)
-
-extern void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
-                                       const struct tunnel_info& tunnel_info,
-                                       const ::p4::config::v1::P4Info& p4info,
-                                       bool insert_entry);
-
-extern void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
-                                       const struct tunnel_info& tunnel_info,
-                                       const ::p4::config::v1::P4Info& p4info,
-                                       bool insert_entry);
-
-extern void PrepareFdbTableV4TunnelEntry(
-    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
-    DiagDetail& detail, bool testing = false);
-
-extern void Es2kPrepareFdbTunnelTableEntry(
-    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry,
-    DiagDetail& detail);
-
-extern void Es2kPrepareTunnelTermTableEntry(
-    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
 extern void EncodeDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
                                         const struct ip_mac_map_info& ip_info,
@@ -135,10 +105,6 @@ extern void EncodeV6GeneveEncapAndVlanPopTableEntry(
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
 extern void EncodeV6GeneveEncapTableEntry(
-    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
-
-extern void PrepareRxTunnelSrcPortTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
@@ -201,4 +167,4 @@ extern void EncodeV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 }  // namespace ovsp4rt
 
-#endif  // OVSP4RT_PRIVATE_H_
+#endif  // OVSP4RT_ENCODERS_H_

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
@@ -13,7 +13,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
@@ -13,7 +13,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
@@ -13,7 +13,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
@@ -15,7 +15,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/es2k/CMakeLists.txt
@@ -95,7 +95,6 @@ define_es2k_tunnel_test(geneve_encap_v6_vlan_pop_test)
 define_es2k_test(src_ip_mac_map_table_test)
 define_es2k_test(dst_ip_mac_map_table_test)
 
-define_es2k_test(l2_fwd_tx_prologue_test)
 define_es2k_test(l2_to_v4_tunnel_test)
 define_es2k_test(l2_to_v6_tunnel_test)
 
@@ -119,6 +118,10 @@ define_es2k_tunnel_test(vxlan_encap_v4_table_test)
 define_es2k_tunnel_test(vxlan_encap_v6_table_test)
 define_es2k_tunnel_test(vxlan_encap_v4_vlan_pop_test)
 define_es2k_tunnel_test(vxlan_encap_v6_vlan_pop_test)
+
+if(BUILD_CLIENT)
+  define_es2k_test(l2_fwd_tx_prologue_test)
+endif()
 
 #-----------------------------------------------------------------------
 # client tests

--- a/ovs-p4rt/sidecar/tests/es2k/client/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/tests/es2k/client/CMakeLists.txt
@@ -1,3 +1,5 @@
+# ovs-p4rt/sidecar/tests/es2k/client/
+
 # Copyright 2025 Derek Foster
 # SPDX-License-Identifier: Apache-2.0
 
@@ -5,6 +7,7 @@
 # basic tests
 #-----------------------------------------------------------------------
 define_basic_test(read_l2_to_tunnel_v4_entry_test)
+
 define_basic_test(write_fdb_smac_table_entry_test)
 define_basic_test(write_tunnel_src_port_entry_test)
 define_basic_test(write_vlan_pop_table_entry_test)

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_decap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_decap_table_test.cc
@@ -3,7 +3,7 @@
 
 #include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_config_int.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_encap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_encap_table_test.cc
@@ -3,7 +3,7 @@
 
 #include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_config_int.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_table_v4_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_table_v4_tunnel_test.cc
@@ -8,7 +8,7 @@
 #include "base_mac_learn_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_config_int.h"
 #include "ovsp4rt_util_int.h"  // GetActionId
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
@@ -10,7 +10,7 @@
 #include "es2k/p4_name_mapping.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_config_int.h"
 #include "ovsp4rt_util_int.h"
 #include "p4/config/v1/p4info.pb.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_l2_tunnel_table_entry.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_l2_tunnel_table_entry.cc
@@ -4,7 +4,7 @@
 #include "base_mac_learn_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_config_int.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_rx_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_rx_tunnel_src_port_test.cc
@@ -7,7 +7,7 @@
 
 #include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_config_int.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_tunnel_term_entry_test.cc
@@ -7,7 +7,7 @@
 
 #include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_config_int.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
@@ -15,7 +15,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
@@ -12,7 +12,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
@@ -13,7 +13,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
@@ -15,7 +15,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
@@ -9,7 +9,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
@@ -8,7 +8,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
@@ -11,7 +11,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
@@ -11,7 +11,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
@@ -11,7 +11,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/l2_fwd_tx_prologue_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_fwd_tx_prologue_test.cc
@@ -12,7 +12,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
@@ -14,7 +14,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
@@ -10,7 +10,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
@@ -12,7 +12,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
@@ -12,7 +12,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
@@ -13,7 +13,7 @@
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
@@ -13,7 +13,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
@@ -12,7 +12,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
@@ -13,7 +13,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/unit_test_template.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/unit_test_template.cc
@@ -14,7 +14,7 @@
 #include "logging/ovsp4rt_diag_detail.h"
 #endif
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
@@ -10,7 +10,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 #include "p4/config/v1/p4info.pb.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
@@ -11,7 +11,7 @@
 #include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
@@ -11,7 +11,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
@@ -11,7 +11,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
@@ -10,7 +10,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
@@ -10,7 +10,7 @@
 #include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
-#include "ovsp4rt_private.h"
+#include "ovsp4rt_encoders.h"
 
 namespace ovsp4rt {
 


### PR DESCRIPTION
- Renamed `ovsp4rt_private.h` to `ovsp4rt_encoders.h`.

- Moved 'Prepare' function prototypes to `ovsp4rt_config_int.h`.

- Limited `l2_fwd_tx_prologue_test` to client builds.