### PR TITLE
Rename unit test base classes

### DIFF
--- a/ovs-p4rt/sidecar/tests/cmake/mac_learn_info_test.cmake
+++ b/ovs-p4rt/sidecar/tests/cmake/mac_learn_info_test.cmake
@@ -8,22 +8,22 @@
 #-----------------------------------------------------------------------
 # ovsp4rt::mac_learn_info_test
 #-----------------------------------------------------------------------
-add_library(base_mac_learn_info_test STATIC
-  base_mac_learn_info_test.cc
-  base_mac_learn_info_test.h
+add_library(mac_learn_info_test STATIC
+  mac_learn_info_test.cc
+  mac_learn_info_test.h
 )
 
-target_include_directories(base_mac_learn_info_test PUBLIC
+target_include_directories(mac_learn_info_test PUBLIC
   ${OVSP4RT_INCLUDE_DIR}
   ${SIDECAR_SOURCE_DIR}
   ${TESTS_SOURCE_DIR}
 )
 
-target_link_libraries(base_mac_learn_info_test PUBLIC
+target_link_libraries(mac_learn_info_test PUBLIC
   ovsp4rt::basic_test
 )
 
-add_library(ovsp4rt::mac_learn_info_test ALIAS base_mac_learn_info_test)
+add_library(ovsp4rt::mac_learn_info_test ALIAS mac_learn_info_test)
 
 #-----------------------------------------------------------------------
 # define_mac_learn_info_test()

--- a/ovs-p4rt/sidecar/tests/cmake/mac_map_info_test.cmake
+++ b/ovs-p4rt/sidecar/tests/cmake/mac_map_info_test.cmake
@@ -8,22 +8,22 @@
 #-----------------------------------------------------------------------
 # ovsp4rt::mac_map_info_test
 #-----------------------------------------------------------------------
-add_library(base_mac_map_info_test STATIC
-  base_mac_map_info_test.cc
-  base_mac_map_info_test.h
+add_library(mac_map_info_test STATIC
+  mac_map_info_test.cc
+  mac_map_info_test.h
 )
 
-target_include_directories(base_mac_map_info_test PUBLIC
+target_include_directories(mac_map_info_test PUBLIC
   ${OVSP4RT_INCLUDE_DIR}
   ${SIDECAR_SOURCE_DIR}
   ${TESTS_SOURCE_DIR}
 )
 
-target_link_libraries(base_mac_map_info_test PUBLIC
+target_link_libraries(mac_map_info_test PUBLIC
   ovsp4rt::basic_test
 )
 
-add_library(ovsp4rt::mac_map_info_test ALIAS base_mac_map_info_test)
+add_library(ovsp4rt::mac_map_info_test ALIAS mac_map_info_test)
 
 #-----------------------------------------------------------------------
 # define_mac_map_info_test()

--- a/ovs-p4rt/sidecar/tests/cmake/tunnel_info_test.cmake
+++ b/ovs-p4rt/sidecar/tests/cmake/tunnel_info_test.cmake
@@ -7,22 +7,22 @@
 #-----------------------------------------------------------------------
 # ovsp4rt::tunnel_info_test
 #-----------------------------------------------------------------------
-add_library(base_tunnel_info_test STATIC
-  base_tunnel_info_test.cc
-  base_tunnel_info_test.h
+add_library(tunnel_info_test STATIC
+  tunnel_info_test.cc
+  tunnel_info_test.h
 )
 
-target_include_directories(base_tunnel_info_test PUBLIC
+target_include_directories(tunnel_info_test PUBLIC
   ${OVSP4RT_INCLUDE_DIR}
   ${SIDECAR_SOURCE_DIR}
   ${TESTS_SOURCE_DIR}
 )
 
-target_link_libraries(base_tunnel_info_test PUBLIC
+target_link_libraries(tunnel_info_test PUBLIC
   ovsp4rt::basic_test
 )
 
-add_library(ovsp4rt::tunnel_info_test ALIAS base_tunnel_info_test)
+add_library(ovsp4rt::tunnel_info_test ALIAS tunnel_info_test)
 
 #-----------------------------------------------------------------------
 # define_tunnel_info_test()

--- a/ovs-p4rt/sidecar/tests/common/write_encap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/write_encap_table_entry_test.cc
@@ -14,10 +14,10 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 using ::testing::Return;
 

--- a/ovs-p4rt/sidecar/tests/common/write_encap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/write_encap_table_entry_test.cc
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_tunnel_info_test.h"
+#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -23,7 +23,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteEncapTableEntryTest : public BaseTunnelInfoTest {
+class WriteEncapTableEntryTest : public TunnelInfoTest {
  public:
   WriteEncapTableEntryTest() {}
   virtual ~WriteEncapTableEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/common/write_fdb_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/write_fdb_tunnel_table_entry_test.cc
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_learn_info_test.h"
+#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -23,7 +23,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteFdbTunnelTableEntryTest : public BaseMacLearnInfoTest {
+class WriteFdbTunnelTableEntryTest : public MacLearnInfoTest {
  public:
   WriteFdbTunnelTableEntryTest() {}
   virtual ~WriteFdbTunnelTableEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/common/write_fdb_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/write_fdb_tunnel_table_entry_test.cc
@@ -14,8 +14,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/common/write_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/write_tunnel_term_entry_test.cc
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_tunnel_info_test.h"
+#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt_config_int.h"
 
@@ -22,7 +22,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteTunnelTermEntryTest : public BaseTunnelInfoTest {
+class WriteTunnelTermEntryTest : public TunnelInfoTest {
  public:
   WriteTunnelTermEntryTest() {}
   virtual ~WriteTunnelTermEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/common/write_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/write_tunnel_term_entry_test.cc
@@ -14,9 +14,9 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 using ::testing::Return;
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_decap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_decap_table_test.cc
@@ -1,13 +1,13 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 namespace ovsp4rt {
 
-class Es2kPrepDecapTableTest : public BaseTunnelInfoTest {
+class Es2kPrepDecapTableTest : public TunnelInfoTest {
  public:
   Es2kPrepDecapTableTest() {}
   virtual ~Es2kPrepDecapTableTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_encap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_encap_table_test.cc
@@ -1,13 +1,13 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 namespace ovsp4rt {
 
-class Es2kPrepEncapTableTest : public BaseTunnelInfoTest {
+class Es2kPrepEncapTableTest : public TunnelInfoTest {
  public:
   Es2kPrepEncapTableTest() {}
   virtual ~Es2kPrepEncapTableTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_table_v4_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_table_v4_tunnel_test.cc
@@ -5,8 +5,8 @@
 
 #include <nlohmann/json.hpp>
 
-#include "base_mac_learn_info_test.h"
 #include "es2k/p4_name_mapping.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 #include "ovsp4rt_util_int.h"  // GetActionId
@@ -15,7 +15,7 @@
 
 namespace ovsp4rt {
 
-class Es2kPrepFdbTableV4TunnelTest : public BaseMacLearnInfoTest {
+class Es2kPrepFdbTableV4TunnelTest : public MacLearnInfoTest {
  public:
   Es2kPrepFdbTableV4TunnelTest() {}
   virtual ~Es2kPrepFdbTableV4TunnelTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
@@ -6,9 +6,9 @@
 #include <absl/status/status.h>
 #include <gtest/gtest.h>
 
-#include "base_mac_learn_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "logging/ovsp4rt_diag_detail.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 #include "ovsp4rt_util_int.h"
@@ -18,7 +18,7 @@ namespace ovsp4rt {
 
 constexpr char GRPC_ADDR[] = "1.2.3.4:5678";
 
-class Es2kPrepFdbTunnelTableTest : public BaseMacLearnInfoTest {
+class Es2kPrepFdbTunnelTableTest : public MacLearnInfoTest {
  protected:
   Es2kPrepFdbTunnelTableTest() {}
   virtual ~Es2kPrepFdbTunnelTableTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_l2_tunnel_table_entry.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_l2_tunnel_table_entry.cc
@@ -1,8 +1,8 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#include "base_mac_learn_info_test.h"
 #include "es2k/p4_name_mapping.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 #include "p4/config/v1/p4info.pb.h"
@@ -10,7 +10,7 @@
 
 namespace ovsp4rt {
 
-class Es2kPrepL2TunnelEntryTest : public BaseMacLearnInfoTest {
+class Es2kPrepL2TunnelEntryTest : public MacLearnInfoTest {
  public:
   Es2kPrepL2TunnelEntryTest() {}
   virtual ~Es2kPrepL2TunnelEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_rx_tunnel_src_port_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_rx_tunnel_src_port_test.cc
@@ -5,13 +5,13 @@
 
 #include <gtest/gtest.h>
 
-#include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 namespace ovsp4rt {
 
-class Es2kPrepRxTunnelSrcPortTest : public BaseTunnelInfoTest {
+class Es2kPrepRxTunnelSrcPortTest : public TunnelInfoTest {
  public:
   Es2kPrepRxTunnelSrcPortTest() {}
   virtual ~Es2kPrepRxTunnelSrcPortTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_tunnel_term_entry_test.cc
@@ -5,13 +5,13 @@
 
 #include <gtest/gtest.h>
 
-#include "base_tunnel_info_test.h"
 #include "es2k/p4_name_mapping.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 namespace ovsp4rt {
 
-class Es2kPrepTunnelTermEntryTest : public BaseTunnelInfoTest {
+class Es2kPrepTunnelTermEntryTest : public TunnelInfoTest {
  public:
   Es2kPrepTunnelTermEntryTest() {}
   virtual ~Es2kPrepTunnelTermEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_tunnel_entry_test.cc
@@ -16,8 +16,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_tunnel_entry_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_learn_info_test.h"
+#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -26,7 +26,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class ReadFdbTunnelEntryTest : public BaseMacLearnInfoTest {
+class ReadFdbTunnelEntryTest : public MacLearnInfoTest {
  public:
   ReadFdbTunnelEntryTest() {}
   virtual ~ReadFdbTunnelEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_vlan_entry_test.cc
@@ -16,8 +16,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_vlan_entry_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_learn_info_test.h"
+#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -26,7 +26,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class ReadFdbVlanEntryTest : public BaseMacLearnInfoTest {
+class ReadFdbVlanEntryTest : public MacLearnInfoTest {
  public:
   ReadFdbVlanEntryTest() {}
   virtual ~ReadFdbVlanEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_l2_to_tunnel_v6_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_l2_to_tunnel_v6_entry_test.cc
@@ -16,8 +16,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_l2_to_tunnel_v6_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_l2_to_tunnel_v6_entry_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_learn_info_test.h"
+#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -26,7 +26,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class ReadL2ToTunnelV6EntryTest : public BaseMacLearnInfoTest {
+class ReadL2ToTunnelV6EntryTest : public MacLearnInfoTest {
  public:
   ReadL2ToTunnelV6EntryTest() {}
   virtual ~ReadL2ToTunnelV6EntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_vm_dst_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_vm_dst_table_entry_test.cc
@@ -16,8 +16,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_map_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_vm_dst_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_vm_dst_table_entry_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_map_info_test.h"
+#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -26,7 +26,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class ReadVmDstTableEntryTest : public BaseMacMapInfoTest {
+class ReadVmDstTableEntryTest : public MacMapInfoTest {
  public:
   ReadVmDstTableEntryTest() {}
   virtual ~ReadVmDstTableEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_vm_src_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_vm_src_table_entry_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_map_info_test.h"
+#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -26,7 +26,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class ReadVmSrcTableEntryTest : public BaseMacMapInfoTest {
+class ReadVmSrcTableEntryTest : public MacMapInfoTest {
  public:
   ReadVmSrcTableEntryTest() {}
   virtual ~ReadVmSrcTableEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_vm_src_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_vm_src_table_entry_test.cc
@@ -16,8 +16,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_map_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_decap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_decap_table_entry_test.cc
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_tunnel_info_test.h"
+#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -23,7 +23,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteDecapTableEntryTest : public BaseTunnelInfoTest {
+class WriteDecapTableEntryTest : public TunnelInfoTest {
  public:
   WriteDecapTableEntryTest() {}
   virtual ~WriteDecapTableEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_decap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_decap_table_entry_test.cc
@@ -14,10 +14,10 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 using ::testing::Return;
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_dst_ip_mac_map_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_dst_ip_mac_map_entry_test.cc
@@ -11,8 +11,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_map_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_dst_ip_mac_map_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_dst_ip_mac_map_entry_test.cc
@@ -11,7 +11,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_map_info_test.h"
+#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -20,7 +20,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteDstIpMacMapEntryTest : public BaseMacMapInfoTest {
+class WriteDstIpMacMapEntryTest : public MacMapInfoTest {
  protected:
   WriteDstIpMacMapEntryTest() {}
   virtual ~WriteDstIpMacMapEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_l2_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_l2_tunnel_table_entry_test.cc
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_learn_info_test.h"
+#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -23,7 +23,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteL2TunnelTableEntryTest : public BaseMacLearnInfoTest {
+class WriteL2TunnelTableEntryTest : public MacLearnInfoTest {
  public:
   WriteL2TunnelTableEntryTest() {}
   virtual ~WriteL2TunnelTableEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_l2_tunnel_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_l2_tunnel_table_entry_test.cc
@@ -14,8 +14,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_learn_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_learn_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_rx_tunnel_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_rx_tunnel_port_entry_test.cc
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_tunnel_info_test.h"
+#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt_config_int.h"
 
@@ -22,7 +22,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteRxTunnelPortEntryTest : public BaseTunnelInfoTest {
+class WriteRxTunnelPortEntryTest : public TunnelInfoTest {
  public:
   WriteRxTunnelPortEntryTest() {}
   virtual ~WriteRxTunnelPortEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_rx_tunnel_port_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_rx_tunnel_port_entry_test.cc
@@ -14,9 +14,9 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "tunnel_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt_config_int.h"
+#include "tunnel_info_test.h"
 
 using ::testing::Return;
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_src_ip_mac_map_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_src_ip_mac_map_entry_test.cc
@@ -11,7 +11,7 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "base_mac_map_info_test.h"
+#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
@@ -20,7 +20,7 @@ using ::testing::Return;
 
 namespace ovsp4rt {
 
-class WriteSrcIpMacMapEntryTest : public BaseMacMapInfoTest {
+class WriteSrcIpMacMapEntryTest : public MacMapInfoTest {
  protected:
   WriteSrcIpMacMapEntryTest() {}
   virtual ~WriteSrcIpMacMapEntryTest() = default;

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_src_ip_mac_map_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_src_ip_mac_map_entry_test.cc
@@ -11,8 +11,8 @@
 #include <gmock/gmock.h>
 // clang-format on
 
-#include "mac_map_info_test.h"
 #include "client/ovsp4rt_test_client_mock.h"
+#include "mac_map_info_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_config_int.h"
 

--- a/ovs-p4rt/sidecar/tests/mac_learn_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/mac_learn_info_test.cc
@@ -2,7 +2,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#include "base_mac_learn_info_test.h"
+#include "mac_learn_info_test.h"
 
 #include <absl/status/status.h>
 #include <arpa/inet.h>
@@ -13,8 +13,7 @@
 
 namespace ovsp4rt {
 
-void BaseMacLearnInfoTest::InitV4TunnelInfo(
-    struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitV4TunnelInfo(struct mac_learning_info& fdb_info) {
   constexpr char IPV4_SRC_ADDR[] = "10.20.30.40";
   constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
   constexpr int IPV4_PREFIX_LEN = 24;
@@ -43,8 +42,7 @@ void BaseMacLearnInfoTest::InitV4TunnelInfo(
   tnl_info.vni = VNI;
 };
 
-void BaseMacLearnInfoTest::InitV6TunnelInfo(
-    struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitV6TunnelInfo(struct mac_learning_info& fdb_info) {
   constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
   constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
   constexpr int IPV6_PREFIX_LEN = 64;
@@ -74,15 +72,14 @@ void BaseMacLearnInfoTest::InitV6TunnelInfo(
   tnl_info.vni = VNI;
 };
 
-void BaseMacLearnInfoTest::InitV4NativeTagged(
-    struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitV4NativeTagged(struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.local_ip.family = AF_INET;
   fdb_info.tnl_info.remote_ip.family = AF_INET;
   fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
   fdb_info.tnl_info.vni = 0x1984U;
 }
 
-void BaseMacLearnInfoTest::InitV4NativeUntagged(
+void MacLearnInfoTest::InitV4NativeUntagged(
     struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.local_ip.family = AF_INET;
   fdb_info.tnl_info.remote_ip.family = AF_INET;
@@ -90,15 +87,14 @@ void BaseMacLearnInfoTest::InitV4NativeUntagged(
   fdb_info.tnl_info.vni = 0x1776U;
 }
 
-void BaseMacLearnInfoTest::InitV6NativeTagged(
-    struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitV6NativeTagged(struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.local_ip.family = AF_INET6;
   fdb_info.tnl_info.remote_ip.family = AF_INET6;
   fdb_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
   fdb_info.tnl_info.vni = 0xFACEU;
 }
 
-void BaseMacLearnInfoTest::InitV6NativeUntagged(
+void MacLearnInfoTest::InitV6NativeUntagged(
     struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.local_ip.family = AF_INET6;
   fdb_info.tnl_info.remote_ip.family = AF_INET6;
@@ -106,36 +102,33 @@ void BaseMacLearnInfoTest::InitV6NativeUntagged(
   fdb_info.tnl_info.vni = 0xCEDEU;
 }
 
-void BaseMacLearnInfoTest::InitVxlanTagged(struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitVxlanTagged(struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.tunnel_type = OVS_TUNNEL_VXLAN;
   fdb_info.tnl_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
   fdb_info.tnl_info.vni = 0x1066;
 }
 
-void BaseMacLearnInfoTest::InitVxlanUntagged(
-    struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitVxlanUntagged(struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.tunnel_type = OVS_TUNNEL_VXLAN;
   fdb_info.tnl_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
   fdb_info.tnl_info.vni = 0x1492;
 }
 
-void BaseMacLearnInfoTest::InitGeneveTagged(
-    struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitGeneveTagged(struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.tunnel_type = OVS_TUNNEL_GENEVE;
   fdb_info.tnl_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
   fdb_info.tnl_info.vni = 0x1776;
 }
 
-void BaseMacLearnInfoTest::InitGeneveUntagged(
-    struct mac_learning_info& fdb_info) {
+void MacLearnInfoTest::InitGeneveUntagged(struct mac_learning_info& fdb_info) {
   fdb_info.tnl_info.tunnel_type = OVS_TUNNEL_GENEVE;
   fdb_info.tnl_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
   fdb_info.tnl_info.vni = 0x1984;
 }
 
-void BaseMacLearnInfoTest::AssertTableId(const p4::v1::TableEntry& table_entry,
-                                         const ::p4::config::v1::P4Info& p4info,
-                                         const char* table_name) {
+void MacLearnInfoTest::AssertTableId(const p4::v1::TableEntry& table_entry,
+                                     const ::p4::config::v1::P4Info& p4info,
+                                     const char* table_name) {
   auto expected_id = GetTableId(p4info, table_name);
   EXPECT_EQ(table_entry.table_id(), expected_id);
 }

--- a/ovs-p4rt/sidecar/tests/mac_learn_info_test.h
+++ b/ovs-p4rt/sidecar/tests/mac_learn_info_test.h
@@ -13,10 +13,10 @@
 
 namespace ovsp4rt {
 
-class BaseMacLearnInfoTest : public BasicTest {
+class MacLearnInfoTest : public BasicTest {
  protected:
-  BaseMacLearnInfoTest() {}
-  virtual ~BaseMacLearnInfoTest() = default;
+  MacLearnInfoTest() {}
+  virtual ~MacLearnInfoTest() = default;
 
   static void InitV4TunnelInfo(struct mac_learning_info& fdb_info);
   static void InitV6TunnelInfo(struct mac_learning_info& fdb_info);

--- a/ovs-p4rt/sidecar/tests/mac_map_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/mac_map_info_test.cc
@@ -2,7 +2,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#include "base_mac_map_info_test.h"
+#include "mac_map_info_test.h"
 
 #include <arpa/inet.h>
 
@@ -11,7 +11,7 @@
 
 namespace ovsp4rt {
 
-void BaseMacMapInfoTest::InitIpv4MapInfo(struct ip_mac_map_info map_info) {
+void MacMapInfoTest::InitIpv4MapInfo(struct ip_mac_map_info map_info) {
   constexpr uint8_t SRC_MAC[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
   constexpr char IPV4_SRC_ADDR[] = "10.20.30.40";
   constexpr int IPV4_PREFIX_LEN = 24;

--- a/ovs-p4rt/sidecar/tests/mac_map_info_test.h
+++ b/ovs-p4rt/sidecar/tests/mac_map_info_test.h
@@ -12,10 +12,10 @@
 
 namespace ovsp4rt {
 
-class BaseMacMapInfoTest : public BasicTest {
+class MacMapInfoTest : public BasicTest {
  protected:
-  BaseMacMapInfoTest() {}
-  virtual ~BaseMacMapInfoTest() = default;
+  MacMapInfoTest() {}
+  virtual ~MacMapInfoTest() = default;
 
   static void InitIpv4MapInfo(struct ip_mac_map_info map_info);
 };

--- a/ovs-p4rt/sidecar/tests/tunnel_info_test.cc
+++ b/ovs-p4rt/sidecar/tests/tunnel_info_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-#include "base_tunnel_info_test.h"
+#include "tunnel_info_test.h"
 
 #include <arpa/inet.h>
 #include <gtest/gtest.h>
@@ -12,7 +12,7 @@
 
 namespace ovsp4rt {
 
-void BaseTunnelInfoTest::InitV4TunnelInfo(struct tunnel_info& tunnel_info) {
+void TunnelInfoTest::InitV4TunnelInfo(struct tunnel_info& tunnel_info) {
   constexpr char IPV4_SRC_ADDR[] = "10.20.30.40";
   constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
   constexpr int IPV4_PREFIX_LEN = 24;
@@ -40,7 +40,7 @@ void BaseTunnelInfoTest::InitV4TunnelInfo(struct tunnel_info& tunnel_info) {
   tunnel_info.vni = VNI;
 };
 
-void BaseTunnelInfoTest::InitV6TunnelInfo(struct tunnel_info& tunnel_info) {
+void TunnelInfoTest::InitV6TunnelInfo(struct tunnel_info& tunnel_info) {
   constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
   constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
   constexpr int IPV6_PREFIX_LEN = 64;
@@ -68,33 +68,33 @@ void BaseTunnelInfoTest::InitV6TunnelInfo(struct tunnel_info& tunnel_info) {
   tunnel_info.vni = VNI;
 };
 
-void BaseTunnelInfoTest::InitVxlanTagged(struct tunnel_info& tunnel_info) {
+void TunnelInfoTest::InitVxlanTagged(struct tunnel_info& tunnel_info) {
   tunnel_info.tunnel_type = OVS_TUNNEL_VXLAN;
   tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
   tunnel_info.vni = 0x1066;
 }
 
-void BaseTunnelInfoTest::InitVxlanUntagged(struct tunnel_info& tunnel_info) {
+void TunnelInfoTest::InitVxlanUntagged(struct tunnel_info& tunnel_info) {
   tunnel_info.tunnel_type = OVS_TUNNEL_VXLAN;
   tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
   tunnel_info.vni = 0x1492;
 }
 
-void BaseTunnelInfoTest::InitGeneveTagged(struct tunnel_info& tunnel_info) {
+void TunnelInfoTest::InitGeneveTagged(struct tunnel_info& tunnel_info) {
   tunnel_info.tunnel_type = OVS_TUNNEL_GENEVE;
   tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
   tunnel_info.vni = 0x1776;
 }
 
-void BaseTunnelInfoTest::InitGeneveUntagged(struct tunnel_info& tunnel_info) {
+void TunnelInfoTest::InitGeneveUntagged(struct tunnel_info& tunnel_info) {
   tunnel_info.tunnel_type = OVS_TUNNEL_GENEVE;
   tunnel_info.vlan_info.port_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
   tunnel_info.vni = 0x1984;
 }
 
-void BaseTunnelInfoTest::AssertTableId(const p4::v1::TableEntry& table_entry,
-                                       const ::p4::config::v1::P4Info& p4info,
-                                       const char* table_name) {
+void TunnelInfoTest::AssertTableId(const p4::v1::TableEntry& table_entry,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   const char* table_name) {
   auto expected_id = GetTableId(p4info, table_name);
   EXPECT_EQ(table_entry.table_id(), expected_id);
 }

--- a/ovs-p4rt/sidecar/tests/tunnel_info_test.h
+++ b/ovs-p4rt/sidecar/tests/tunnel_info_test.h
@@ -13,10 +13,10 @@
 
 namespace ovsp4rt {
 
-class BaseTunnelInfoTest : public BasicTest {
+class TunnelInfoTest : public BasicTest {
  protected:
-  BaseTunnelInfoTest(){};
-  virtual ~BaseTunnelInfoTest() = default;
+  TunnelInfoTest(){};
+  virtual ~TunnelInfoTest() = default;
 
   static void InitV4TunnelInfo(struct tunnel_info& tunnel_info);
   static void InitV6TunnelInfo(struct tunnel_info& tunnel_info);


### PR DESCRIPTION
- Removed the `Base` prefix from `BaseMacLearnInfoTest`, `BaseMacMapInfoTest` and `BaseTunnelInfoTest`.