### PR TITLE
Treat absl/gmock/gtest/grpc/protobuf as system includes

### DIFF
--- a/ovs-p4rt/sidecar/client/ovsp4rt_client.cc
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client.cc
@@ -3,9 +3,10 @@
 
 #include "ovsp4rt_client.h"
 
-#include "absl/flags/flag.h"
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
+#include <absl/flags/flag.h>
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
+
 #include "ovsp4rt_client_flags.h"
 #include "session/ovsp4rt_credentials.h"
 #include "session/ovsp4rt_session.h"

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client.h
@@ -4,10 +4,10 @@
 #ifndef OVSP4RT_CLIENT_H_
 #define OVSP4RT_CLIENT_H_
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
 #include <stdint.h>
 
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
 #include "ovsp4rt_client_interface.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "session/ovsp4rt_session.h"

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client_interface.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client_interface.h
@@ -4,8 +4,9 @@
 #ifndef OVSP4RT_CLIENT_INTERFACE_H_
 #define OVSP4RT_CLIENT_INTERFACE_H_
 
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
+
 #include "p4/v1/p4runtime.pb.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client_mock.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client_mock.h
@@ -4,7 +4,8 @@
 #ifndef OVSP4RT_CLIENT_MOCK_H_
 #define OVSP4RT_CLIENT_MOCK_H_
 
-#include "gmock/gmock.h"
+#include <gmock/gmock.h>
+
 #include "ovsp4rt_client_interface.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.h
@@ -4,8 +4,9 @@
 #ifndef OVSP4RT_JOURNAL_CLIENT_H_
 #define OVSP4RT_JOURNAL_CLIENT_H_
 
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
+
 #include "client/ovsp4rt_client.h"
 #include "journal/ovsp4rt_journal.h"
 #include "p4/v1/p4runtime.pb.h"

--- a/ovs-p4rt/sidecar/client/ovsp4rt_test_client.cc
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_test_client.cc
@@ -4,9 +4,10 @@
 
 #include "ovsp4rt_test_client.h"
 
-#include "absl/flags/flag.h"
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
+#include <absl/flags/flag.h>
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
+
 #include "ovsp4rt_client.h"
 #include "ovsp4rt_client_flags.h"
 

--- a/ovs-p4rt/sidecar/client/ovsp4rt_test_client.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_test_client.h
@@ -5,10 +5,10 @@
 #ifndef OVSP4RT_TEST_CLIENT_H_
 #define OVSP4RT_TEST_CLIENT_H_
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
 #include <stdint.h>
 
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
 #include "ovsp4rt_client_interface.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "session/ovsp4rt_session.h"

--- a/ovs-p4rt/sidecar/client/ovsp4rt_test_client_mock.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_test_client_mock.h
@@ -5,7 +5,8 @@
 #ifndef OVSP4RT_TEST_CLIENT_MOCK_H_
 #define OVSP4RT_TEST_CLIENT_MOCK_H_
 
-#include "gmock/gmock.h"
+#include <gmock/gmock.h>
+
 #include "ovsp4rt_test_client.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/core/v1/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/core/v1/ovsp4rt.cc
@@ -2,11 +2,11 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
+#include <absl/flags/flag.h>
 #include <arpa/inet.h>
 
 #include <string>
 
-#include "absl/flags/flag.h"
 #include "core/ovsp4rt_encoders.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "logging/ovsp4rt_logging.h"

--- a/ovs-p4rt/sidecar/core/v2/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/core/v2/newovsp4rt.cc
@@ -2,11 +2,11 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
+#include <absl/flags/flag.h>
 #include <arpa/inet.h>
 
 #include <string>
 
-#include "absl/flags/flag.h"
 #include "client/ovsp4rt_client.h"
 #include "core/ovsp4rt_config_int.h"
 #include "core/ovsp4rt_encoders.h"

--- a/ovs-p4rt/sidecar/core/v2/ovsp4rt_do_config_int.h
+++ b/ovs-p4rt/sidecar/core/v2/ovsp4rt_do_config_int.h
@@ -8,7 +8,8 @@
 #ifndef OVSP4RT_DO_CONFIG_INT_H_
 #define OVSP4RT_DO_CONFIG_INT_H_
 
-#include "absl/status/status.h"
+#include <absl/status/status.h>
+
 #include "client/ovsp4rt_client_interface.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/journal/encode_addr_test.cc
+++ b/ovs-p4rt/sidecar/journal/encode_addr_test.cc
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
 #include <nlohmann/json.hpp>
 
 #include "encode_base_test.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_encode_inputs.h"
 

--- a/ovs-p4rt/sidecar/journal/encode_base_test.h
+++ b/ovs-p4rt/sidecar/journal/encode_base_test.h
@@ -4,10 +4,9 @@
 #ifndef ENCODE_BASE_TEST_H_
 #define ENCODE_BASE_TEST_H_
 
+#include <absl/flags/flag.h>
+#include <gtest/gtest.h>
 #include <stdbool.h>
-
-#include "absl/flags/flag.h"
-#include "gtest/gtest.h"
 
 ABSL_FLAG(bool, dump_json, false, "Dump JSON output");
 

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode_actions.cc
@@ -3,11 +3,11 @@
 
 #include "ovsp4rt_encode_actions.h"
 
+#include <absl/status/statusor.h>
 #include <google/protobuf/util/json_util.h>
 
 #include <nlohmann/json.hpp>
 
-#include "absl/status/statusor.h"
 #include "p4/v1/p4runtime.pb.h"
 
 namespace {

--- a/ovs-p4rt/sidecar/journal/test_main.cc
+++ b/ovs-p4rt/sidecar/journal/test_main.cc
@@ -1,8 +1,8 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include "absl/flags/parse.h"
-#include "gtest/gtest.h"
+#include <absl/flags/parse.h>
+#include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
   // As part of initialization, this function parses the command line,

--- a/ovs-p4rt/sidecar/session/ovsp4rt_credentials.h
+++ b/ovs-p4rt/sidecar/session/ovsp4rt_credentials.h
@@ -6,15 +6,13 @@
 #ifndef OVSP4RT_CREDENTIALS_H_
 #define OVSP4RT_CREDENTIALS_H_
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
 #include <grpcpp/grpcpp.h>
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/security/tls_credentials_options.h>
 
 #include <string>
-
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
-#include "grpcpp/grpcpp.h"
-#include "grpcpp/security/server_credentials.h"
-#include "grpcpp/security/tls_credentials_options.h"
 
 #define DEFAULT_CERTS_DIR "/usr/share/stratum/certs/"
 

--- a/ovs-p4rt/sidecar/session/ovsp4rt_session.cc
+++ b/ovs-p4rt/sidecar/session/ovsp4rt_session.cc
@@ -5,12 +5,13 @@
 
 #include "ovsp4rt_session.h"
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/create_channel.h>
+
 #include <string>
 
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
-#include "grpcpp/channel.h"
-#include "grpcpp/create_channel.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/status/status.h"

--- a/ovs-p4rt/sidecar/session/ovsp4rt_session.h
+++ b/ovs-p4rt/sidecar/session/ovsp4rt_session.h
@@ -6,6 +6,10 @@
 #ifndef OVSP4RT_SESSION_H_
 #define OVSP4RT_SESSION_H_
 
+#include <absl/status/status.h>
+#include <absl/status/statusor.h>
+#include <absl/time/clock.h>
+#include <absl/time/time.h>
 #include <grpcpp/grpcpp.h>
 
 #include <fstream>
@@ -13,10 +17,6 @@
 #include <sstream>
 #include <string>
 
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
-#include "absl/time/clock.h"
-#include "absl/time/time.h"
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 

--- a/ovs-p4rt/sidecar/tests/dpdk/base_table_test.h
+++ b/ovs-p4rt/sidecar/tests/dpdk/base_table_test.h
@@ -15,10 +15,12 @@
 #include <string>
 
 #ifdef DUMP_JSON
-#include "absl/flags/flag.h"
+#include <absl/flags/flag.h>
+
 #include "google/protobuf/util/json_util.h"
 #endif
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4info_helper.h"

--- a/ovs-p4rt/sidecar/tests/dpdk/base_table_test.h
+++ b/ovs-p4rt/sidecar/tests/dpdk/base_table_test.h
@@ -16,8 +16,7 @@
 
 #ifdef DUMP_JSON
 #include <absl/flags/flag.h>
-
-#include "google/protobuf/util/json_util.h"
+#include <google/protobuf/util/json_util.h>
 #endif
 #include <gtest/gtest.h>
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_rx_vlan_test.cc
@@ -4,6 +4,7 @@
 // Unit test for EncodeFdbRxVlanTableEntry().
 // DPDK version.
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vlan_test.cc
@@ -4,6 +4,7 @@
 // Unit test for EncodeFdbTxVlanTableEntry().
 // DPDK edition.
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_fdb_tx_vxlan_test.cc
@@ -5,6 +5,7 @@
 // DPDK version.
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -12,7 +13,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_tunnel_term_test.cc
@@ -7,6 +7,7 @@
 #define DUMP_JSON
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -14,7 +15,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
+++ b/ovs-p4rt/sidecar/tests/dpdk/dpdk_vxlan_encap_test.cc
@@ -6,11 +6,11 @@
 
 #define DUMP_JSON
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/base_table_test.h
+++ b/ovs-p4rt/sidecar/tests/es2k/base_table_test.h
@@ -15,10 +15,12 @@
 #include <string>
 
 #ifdef DUMP_JSON
-#include "absl/flags/flag.h"
+#include <absl/flags/flag.h>
+
 #include "google/protobuf/util/json_util.h"
 #endif
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "p4/config/v1/p4info.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4info_helper.h"

--- a/ovs-p4rt/sidecar/tests/es2k/base_table_test.h
+++ b/ovs-p4rt/sidecar/tests/es2k/base_table_test.h
@@ -16,8 +16,7 @@
 
 #ifdef DUMP_JSON
 #include <absl/flags/flag.h>
-
-#include "google/protobuf/util/json_util.h"
+#include <google/protobuf/util/json_util.h>
 #endif
 #include <gtest/gtest.h>
 

--- a/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/dst_ip_mac_map_table_test.cc
@@ -6,6 +6,7 @@
 //#define DUMP_JSON
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -13,7 +14,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_rx_vlan_entry_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeFdbRxVlanTableEntry()
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_smac_entry_test.cc
@@ -4,6 +4,7 @@
 // Unit test for EncodeFdbSmacTableEntry()
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeFdbTableEntryforV4GeneveTunnel().
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vlan_entry_test.cc
@@ -6,6 +6,7 @@
 // TODO(derek): port and vlan_ptr parameter values are truncated to
 // 8 bits. Need to fix or document why this is correct.
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -13,7 +14,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_vxlan_entry_test.cc
@@ -1,6 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -8,7 +9,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_table_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeGeneveDecapModTableEntry()
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_decap_mod_vlan_push_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeGeneveDecapModAndVlanPushTableEntry().
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_table_test.cc
@@ -3,10 +3,10 @@
 
 // Unit test for EncodeGeneveEncapTableEntry().
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v4_vlan_pop_test.cc
@@ -5,11 +5,11 @@
 
 #define DUMP_JSON
 
+#include <absl/types/optional.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
-#include "absl/types/optional.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_table_test.cc
@@ -5,11 +5,11 @@
 
 #define DUMP_JSON
 
+#include <absl/types/optional.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
-#include "absl/types/optional.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/geneve_encap_v6_vlan_pop_test.cc
@@ -3,13 +3,13 @@
 
 // Unit test for EncodeV6GeneveEncapAndVlanPopTableEntry().
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
 #include <string>
 
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/ip_tunnel_test.h
+++ b/ovs-p4rt/sidecar/tests/es2k/ip_tunnel_test.h
@@ -5,9 +5,9 @@
 #define IP_TUNNEL_TEST_H_
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 
 #include "base_table_test.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/l2_fwd_tx_prologue_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_fwd_tx_prologue_test.cc
@@ -4,6 +4,7 @@
 
 // Unit test for EncodeL2FwdTxTablePrologue()
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v4_tunnel_test.cc
@@ -6,13 +6,13 @@
 #define DUMP_JSON
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 
 #include <iostream>
 #include <string>
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/l2_to_v6_tunnel_test.cc
@@ -3,12 +3,13 @@
 
 // Unit test for EncodeL2ToTunnelV6().
 
+#include <gtest/gtest.h>
+
 #include <iostream>
 #include <string>
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v4_table_test.cc
@@ -4,6 +4,7 @@
 // Unit test for EncodeRxTunnelTableEntry().
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/rx_tunnel_v6_table_test.cc
@@ -4,6 +4,7 @@
 // Unit test for EncodeV6RxTunnelTableEntry().
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_ip_mac_map_table_test.cc
@@ -4,6 +4,7 @@
 // Unit test for EncodeSrcIpMacMapTableEntry()
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/src_port_table_test.cc
@@ -5,6 +5,7 @@
 
 #define DUMP_JSON
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -12,7 +13,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/table_entry_test.h
+++ b/ovs-p4rt/sidecar/tests/es2k/table_entry_test.h
@@ -4,15 +4,15 @@
 #ifndef TABLE_ENTRY_TEST_H_
 #define TABLE_ENTRY_TEST_H_
 
+#include <absl/flags/flag.h>
+#include <gtest/gtest.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include <iostream>
 #include <string>
 
-#include "absl/flags/flag.h"
 #include "google/protobuf/util/json_util.h"
-#include "gtest/gtest.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"

--- a/ovs-p4rt/sidecar/tests/es2k/table_entry_test.h
+++ b/ovs-p4rt/sidecar/tests/es2k/table_entry_test.h
@@ -5,6 +5,7 @@
 #define TABLE_ENTRY_TEST_H_
 
 #include <absl/flags/flag.h>
+#include <google/protobuf/util/json_util.h>
 #include <gtest/gtest.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -12,7 +13,6 @@
 #include <iostream>
 #include <string>
 
-#include "google/protobuf/util/json_util.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v4_table_test.cc
@@ -4,6 +4,7 @@
 #define DUMP_JSON
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -11,7 +12,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tunnel_term_v6_table_test.cc
@@ -4,6 +4,7 @@
 #define DUMP_JSON
 
 #include <arpa/inet.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -12,7 +13,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/tx_acc_vsi_table_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeTxAccVsiTableEntry()
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_pop_mod_table_test.cc
@@ -3,13 +3,13 @@
 
 // Unit test for EncodeVlanPopTableEntry()
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <string>
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "p4/config/v1/p4info.pb.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vlan_push_mod_table_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeVlanPushTableEntry().
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_table_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeVxlanDecapModTableEntry().
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_decap_mod_vlan_push_test.cc
@@ -3,6 +3,7 @@
 
 // Unit test for EncodeVxlanDecapModAndVlanPushTableEntry().
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <iostream>
@@ -10,7 +11,6 @@
 
 #include "base_table_test.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace ovsp4rt {

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_table_test.cc
@@ -5,11 +5,11 @@
 
 #define DUMP_JSON
 
+#include <absl/types/optional.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
-#include "absl/types/optional.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v4_vlan_pop_test.cc
@@ -5,11 +5,11 @@
 
 #define DUMP_JSON
 
+#include <absl/types/optional.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
-#include "absl/types/optional.h"
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_table_test.cc
@@ -5,10 +5,10 @@
 
 #define DUMP_JSON
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/vxlan_encap_v6_vlan_pop_test.cc
@@ -5,10 +5,10 @@
 
 #define DUMP_JSON
 
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include "core/ovsp4rt_encoders.h"
-#include "gtest/gtest.h"
 #include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 

--- a/ovs-p4rt/sidecar/tests/test_main.cc
+++ b/ovs-p4rt/sidecar/tests/test_main.cc
@@ -1,8 +1,8 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include "absl/flags/parse.h"
-#include "gtest/gtest.h"
+#include <absl/flags/parse.h>
+#include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
   // As part of initialization, this function parses the command line,


### PR DESCRIPTION
- Modified to use angle brackets instead of quotation marks for header files included from abseil, gmock, gtest, grpc, and protobuf.