### PR TITLE
Rename a number of `Prepare` functions

### DIFF
--- a/ovs-p4rt/sidecar/core/common/ovsp4rt_entry_utils.h
+++ b/ovs-p4rt/sidecar/core/common/ovsp4rt_entry_utils.h
@@ -29,29 +29,30 @@ extern void PrepareL2TunnelTableEntry(
 
 #if defined(ES2K_TARGET)
 
-extern void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
-                                       const struct tunnel_info& tunnel_info,
-                                       const ::p4::config::v1::P4Info& p4info,
-                                       bool insert_entry);
+extern void PrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry);
 
-extern void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
-                                       const struct tunnel_info& tunnel_info,
-                                       const ::p4::config::v1::P4Info& p4info,
-                                       bool insert_entry);
+extern void PrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry);
 
 extern void PrepareFdbTableV4TunnelEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail, bool testing = false);
 
-extern void Es2kPrepareFdbTunnelTableEntry(
+extern void PrepareFdbTunnelTableEntry(
     p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry,
     DiagDetail& detail);
 
-extern void Es2kPrepareTunnelTermTableEntry(
-    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
-    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+extern void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry);
 
 extern void PrepareRxTunnelSrcPortTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,

--- a/ovs-p4rt/sidecar/core/v1/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/core/v1/ovsp4rt.cc
@@ -858,10 +858,10 @@ void EncodeGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
-                            const struct tunnel_info& tunnel_info,
-                            const ::p4::config::v1::P4Info& p4info,
-                            bool insert_entry) {
+void PrepareV4EncapTableEntry(p4::v1::TableEntry* table_entry,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
 #if defined(DPDK_TARGET)
   EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
@@ -1135,10 +1135,10 @@ void EncodeGeneveEncapAndVlanPopTableEntry(
   }
 }
 
-void PrepareEncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
-                                      const struct tunnel_info& tunnel_info,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+void PrepareV4EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
     EncodeVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
                                          insert_entry);
@@ -1567,16 +1567,16 @@ absl::Status WriteEncapTableEntry(ovsp4rt::OvsP4rtSession* session,
   }
 
 #if defined(DPDK_TARGET)
-  PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  PrepareV4EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
 #elif defined(ES2K_TARGET)
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
     if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
-      PrepareEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                       insert_entry);
+      PrepareV4EncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                         insert_entry);
     } else {
-      PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+      PrepareV4EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
     }
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {

--- a/ovs-p4rt/sidecar/core/v2/ovsp4rt_v2.cc
+++ b/ovs-p4rt/sidecar/core/v2/ovsp4rt_v2.cc
@@ -133,10 +133,10 @@ absl::Status WriteFdbRxVlanTableEntry(
 
 #if defined(ES2K_TARGET)
 // extracted from WriteFdbTunnelTableEntry
-void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct mac_learning_info& learn_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry, DiagDetail& detail) {
+void PrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct mac_learning_info& learn_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry, DiagDetail& detail) {
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
     EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
                                         insert_entry, detail);
@@ -163,8 +163,8 @@ absl::Status WriteFdbTunnelTableEntry(
   EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
                                       insert_entry, detail);
 #elif defined(ES2K_TARGET)
-  Es2kPrepareFdbTunnelTableEntry(table_entry, learn_info, p4info, insert_entry,
-                                 detail);
+  PrepareFdbTunnelTableEntry(table_entry, learn_info, p4info, insert_entry,
+                             detail);
 #else
 #error "ASSERT: Unknown TARGET type!"
 #endif
@@ -178,10 +178,10 @@ absl::Status WriteFdbTunnelTableEntry(
 }
 
 // Ipv4, Tagged
-void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
-                            const struct tunnel_info& tunnel_info,
-                            const ::p4::config::v1::P4Info& p4info,
-                            bool insert_entry) {
+void PrepareV4EncapTableEntry(p4::v1::TableEntry* table_entry,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
 #if defined(DPDK_TARGET)
   EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
@@ -214,10 +214,10 @@ void PrepareV6EncapTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 // Ipv4, Untagged
-void PrepareEncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
-                                      const struct tunnel_info& tunnel_info,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+void PrepareV4EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
     EncodeVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
                                          insert_entry);
@@ -249,17 +249,17 @@ void PrepareV6EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 // called-by: WriteEncapTableEntry
-void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
-                                const struct tunnel_info& tunnel_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry) {
+void PrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
+                            const struct tunnel_info& tunnel_info,
+                            const ::p4::config::v1::P4Info& p4info,
+                            bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
     if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
-      PrepareEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                       insert_entry);
+      PrepareV4EncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                         insert_entry);
     } else {
-      PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+      PrepareV4EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
     }
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
@@ -284,9 +284,9 @@ absl::Status WriteEncapTableEntry(ClientInterface& client,
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
 #if defined(DPDK_TARGET)
-  PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  PrepareV4EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
-  Es2kPrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #else
 #error "ASSERT: Unknown TARGET type!"
 #endif
@@ -296,7 +296,7 @@ absl::Status WriteEncapTableEntry(ClientInterface& client,
 
 #if defined(ES2K_TARGET)
 
-// called-by: Es2kPrepareDecapTableEntry
+// called-by: PrepareDecapTableEntry
 // port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED
 void PrepareDecapModTableEntry(p4::v1::TableEntry* table_entry,
                                const struct tunnel_info& tunnel_info,
@@ -313,7 +313,7 @@ void PrepareDecapModTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-// called-by: Es2kPrepareDecapTableEntry
+// called-by: PrepareDecapTableEntry
 // port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED
 void PrepareDecapModAndVlanPushTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
@@ -330,10 +330,10 @@ void PrepareDecapModAndVlanPushTableEntry(
 }
 
 // called-by: WriteDecapTableEntry
-void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
-                                const struct tunnel_info& tunnel_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry) {
+void PrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
+                            const struct tunnel_info& tunnel_info,
+                            const ::p4::config::v1::P4Info& p4info,
+                            bool insert_entry) {
   if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED) {
     PrepareDecapModTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else {
@@ -352,7 +352,7 @@ absl::Status WriteDecapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  Es2kPrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  PrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -592,10 +592,10 @@ absl::Status WriteRxTunnelSrcPortTableEntry(
 }
 
 // called-by: WriteTunnelTermTableEntry
-void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct tunnel_info& tunnel_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct tunnel_info& tunnel_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
     EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
@@ -621,8 +621,7 @@ absl::Status WriteTunnelTermTableEntry(ClientInterface& client,
 #if defined(DPDK_TARGET)
   EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #elif defined(ES2K_TARGET)
-  Es2kPrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+  PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 #else
 #error "ASSERT: Unknown TARGET type!"
 #endif

--- a/ovs-p4rt/sidecar/core/v3/dpdk_config_tunnel_entry.cc
+++ b/ovs-p4rt/sidecar/core/v3/dpdk_config_tunnel_entry.cc
@@ -20,10 +20,10 @@ namespace ovsp4rt {
 //----------------------------------------------------------------------
 
 // Ipv4, Tagged
-void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
-                            const struct tunnel_info& tunnel_info,
-                            const ::p4::config::v1::P4Info& p4info,
-                            bool insert_entry) {
+void PrepareV4EncapTableEntry(p4::v1::TableEntry* table_entry,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 }
 
@@ -36,7 +36,7 @@ absl::Status WriteEncapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  PrepareV4EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }

--- a/ovs-p4rt/sidecar/core/v3/es2k_config_fdb_entry.cc
+++ b/ovs-p4rt/sidecar/core/v3/es2k_config_fdb_entry.cc
@@ -111,10 +111,10 @@ absl::Status WriteFdbRxVlanTableEntry(
   return status;
 }
 
-void Es2kPrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
-                                    const struct mac_learning_info& learn_info,
-                                    const ::p4::config::v1::P4Info& p4info,
-                                    bool insert_entry, DiagDetail& detail) {
+void PrepareFdbTunnelTableEntry(p4::v1::TableEntry* table_entry,
+                                const struct mac_learning_info& learn_info,
+                                const ::p4::config::v1::P4Info& p4info,
+                                bool insert_entry, DiagDetail& detail) {
   if (learn_info.tnl_info.tunnel_type == OVS_TUNNEL_VXLAN) {
     EncodeFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
                                         insert_entry, detail);
@@ -136,8 +136,8 @@ absl::Status WriteFdbTunnelTableEntry(
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  Es2kPrepareFdbTunnelTableEntry(table_entry, learn_info, p4info, insert_entry,
-                                 detail);
+  PrepareFdbTunnelTableEntry(table_entry, learn_info, p4info, insert_entry,
+                             detail);
 
   auto status = client.sendWriteRequest(write_request);
   if (!status.ok()) {

--- a/ovs-p4rt/sidecar/core/v3/es2k_config_tunnel_entry.cc
+++ b/ovs-p4rt/sidecar/core/v3/es2k_config_tunnel_entry.cc
@@ -20,10 +20,10 @@ namespace ovsp4rt {
 //----------------------------------------------------------------------
 
 // Ipv4, Tagged
-void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
-                            const struct tunnel_info& tunnel_info,
-                            const ::p4::config::v1::P4Info& p4info,
-                            bool insert_entry) {
+void PrepareV4EncapTableEntry(p4::v1::TableEntry* table_entry,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
+                              bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
     EncodeVxlanEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
@@ -50,10 +50,10 @@ void PrepareV6EncapTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 // Ipv4, Untagged
-void PrepareEncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
-                                      const struct tunnel_info& tunnel_info,
-                                      const ::p4::config::v1::P4Info& p4info,
-                                      bool insert_entry) {
+void PrepareV4EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry) {
   if (tunnel_info.tunnel_type == OVS_TUNNEL_VXLAN) {
     EncodeVxlanEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
                                          insert_entry);
@@ -81,17 +81,17 @@ void PrepareV6EncapAndVlanPopTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-void Es2kPrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
-                                const struct tunnel_info& tunnel_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry) {
+void PrepareEncapTableEntry(::p4::v1::TableEntry* table_entry,
+                            const struct tunnel_info& tunnel_info,
+                            const ::p4::config::v1::P4Info& p4info,
+                            bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
     if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
-      PrepareEncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
-                                       insert_entry);
+      PrepareV4EncapAndVlanPopTableEntry(table_entry, tunnel_info, p4info,
+                                         insert_entry);
     } else {
-      PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+      PrepareV4EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
     }
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
@@ -113,7 +113,7 @@ absl::Status WriteEncapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  Es2kPrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -153,10 +153,10 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
-void Es2kPrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
-                                const struct tunnel_info& tunnel_info,
-                                const ::p4::config::v1::P4Info& p4info,
-                                bool insert_entry) {
+void PrepareDecapTableEntry(::p4::v1::TableEntry* table_entry,
+                            const struct tunnel_info& tunnel_info,
+                            const ::p4::config::v1::P4Info& p4info,
+                            bool insert_entry) {
   if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED) {
     PrepareDecapModTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else {
@@ -174,7 +174,7 @@ absl::Status WriteDecapTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  Es2kPrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+  PrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }
@@ -183,10 +183,10 @@ absl::Status WriteDecapTableEntry(ClientInterface& client,
 // WriteTunnelTermTableEntry
 //----------------------------------------------------------------------
 
-void Es2kPrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
-                                     const struct tunnel_info& tunnel_info,
-                                     const ::p4::config::v1::P4Info& p4info,
-                                     bool insert_entry) {
+void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                 const struct tunnel_info& tunnel_info,
+                                 const ::p4::config::v1::P4Info& p4info,
+                                 bool insert_entry) {
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
     EncodeTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
@@ -206,8 +206,7 @@ absl::Status WriteTunnelTermTableEntry(ClientInterface& client,
 
   table_entry = client.initWriteRequest(&write_request, insert_entry);
 
-  Es2kPrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info,
-                                  insert_entry);
+  PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
   return client.sendWriteRequest(write_request);
 }

--- a/ovs-p4rt/sidecar/tests/common/write_encap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/common/write_encap_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteEncapTableEntry().
 
-// Core functionality is handled by Es2kPrepareEncapTableEntry(),
+// Core functionality is handled by PrepareEncapTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_decap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_decap_table_test.cc
@@ -33,7 +33,7 @@ class Es2kPrepDecapTableTest : public TunnelInfoTest {
   }
 };
 
-// Es2kPrepareDecapTableEntry switches on port_vlan_mode.
+// PrepareDecapTableEntry switches on port_vlan_mode.
 // IP version and tunnel type are irrelevant.
 
 TEST_F(Es2kPrepDecapTableTest, prepareDecapIpv4VxlanTagged) {
@@ -48,7 +48,7 @@ TEST_F(Es2kPrepDecapTableTest, prepareDecapIpv4VxlanTagged) {
 
   // tunnel_type == OVS_TUNNEL_VXLAN
   // port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED
-  Es2kPrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4VxlanTagged(table_entry, p4info);
 }
@@ -65,7 +65,7 @@ TEST_F(Es2kPrepDecapTableTest, prepareDecapIpv4VxlanUntagged) {
 
   // tunnel_type == OVS_TUNNEL_VXLAN
   // port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED
-  Es2kPrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4VxlanUntagged(table_entry, p4info);
 }
@@ -82,7 +82,7 @@ TEST_F(Es2kPrepDecapTableTest, prepareDecapGeneveTagged) {
 
   // tunnel_type == OVS_TUNNEL_GENEVE
   // port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED
-  Es2kPrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4GeneveTagged(table_entry, p4info);
 }
@@ -99,7 +99,7 @@ TEST_F(Es2kPrepDecapTableTest, prepareDecapGeneveUntagged) {
 
   // tunnel_type == OVS_TUNNEL_GENEVE
   // port_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED
-  Es2kPrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareDecapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4GeneveUntagged(table_entry, p4info);
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_encap_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_encap_table_test.cc
@@ -65,7 +65,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv4VxlanUntagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4VxlanUntagged(table_entry, p4info);
 }
@@ -80,7 +80,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv4GeneveUntagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4GeneveUntagged(table_entry, p4info);
 }
@@ -97,7 +97,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv4VxlanTagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4VxlanTagged(table_entry, p4info);
 }
@@ -112,7 +112,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv4GeneveTagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4GeneveTagged(table_entry, p4info);
 }
@@ -129,7 +129,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv6VxlanUntagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV6VxlanUntagged(table_entry, p4info);
 }
@@ -144,7 +144,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv6GeneveUntagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV6GeneveUntagged(table_entry, p4info);
 }
@@ -161,7 +161,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv6VxlanTagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV6VxlanTagged(table_entry, p4info);
 }
@@ -176,7 +176,7 @@ TEST_F(Es2kPrepEncapTableTest, configEncapIpv6GeneveTagged) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV6GeneveTagged(table_entry, p4info);
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_fdb_tunnel_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for Es2kPrepareFdbTunnelTableEntry().
+// Unit test for PrepareFdbTunnelTableEntry().
 
 #include <absl/status/status.h>
 #include <gtest/gtest.h>
@@ -69,8 +69,8 @@ TEST_F(Es2kPrepFdbTunnelTableTest, insertV4VxlanTunnelEntry) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, INSERT_ENTRY,
-                                 detail);
+  PrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, INSERT_ENTRY,
+                             detail);
 
   CheckActionId(table_entry, p4info, OVS_TUNNEL_VXLAN);
 }
@@ -86,8 +86,8 @@ TEST_F(Es2kPrepFdbTunnelTableTest, insertV4GeneveTunnelEntry) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, INSERT_ENTRY,
-                                 detail);
+  PrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, INSERT_ENTRY,
+                             detail);
 
   CheckActionId(table_entry, p4info, OVS_TUNNEL_GENEVE);
 }
@@ -102,8 +102,8 @@ TEST_F(Es2kPrepFdbTunnelTableTest, removeV4TunnelEntry) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, REMOVE_ENTRY,
-                                 detail);
+  PrepareFdbTunnelTableEntry(&table_entry, learn_info, p4info, REMOVE_ENTRY,
+                             detail);
 
   CheckRemoveAction(table_entry);
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_tunnel_term_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/es2k_prep_tunnel_term_entry_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2025 Derek Foster
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for Es2kPrepareTunnelTermTableEntry().
+// Unit test for PrepareTunnelTermTableEntry().
 
 #include <gtest/gtest.h>
 
@@ -37,8 +37,7 @@ TEST_F(Es2kPrepTunnelTermEntryTest, configV4TunnelTermEntry) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                  INSERT_ENTRY);
+  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV4Tunnel(table_entry, p4info);
 }
@@ -53,8 +52,7 @@ TEST_F(Es2kPrepTunnelTermEntryTest, configV6TunnelTermEntry) {
   ::p4::config::v1::P4Info p4info;
   InitP4Info(&p4info);
 
-  Es2kPrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info,
-                                  INSERT_ENTRY);
+  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
 
   AssertV6Tunnel(table_entry, p4info);
 }

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_tunnel_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_fdb_tunnel_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ReadFdbTunnelTableEntry().
 
-// Core functionality is handled by Es2kPrepareTunnelTermTableEntry(),
+// Core functionality is handled by PrepareTunnelTermTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/read_l2_to_tunnel_v4_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/read_l2_to_tunnel_v4_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for ReadL2ToTunnelV4TableEntry().
 
-// Core functionality is handled by Es2kPrepareTunnelTermTableEntry(),
+// Core functionality is handled by PrepareTunnelTermTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 

--- a/ovs-p4rt/sidecar/tests/es2k/client/write_decap_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/client/write_decap_table_entry_test.cc
@@ -3,7 +3,7 @@
 
 // Unit test for WriteDecapTableEntry().
 
-// Core functionality is handled by Es2kPrepareDecapTableEntry(),
+// Core functionality is handled by PrepareDecapTableEntry(),
 // which is tested separately. This is a test of the non-core
 // functionality.
 


### PR DESCRIPTION
Renamed:
- `Es2kPrepareDecapTableEntry` to `PrepareDecapTableEntry`
- `PrepareEncapTableEntry` to `PrepareV4EncapTableEntry`
- `Es2kPrepareEncapTableEntry` to `PrepareEncapTableEntry`
- `PrepareEncapAndVlanPopTableEntry` to `PrepareV4EncapAndVlanPopTableEntry`
- `Es2kPrepareFdbTunnelTableEntry` to `PrepareFdbTunnelTableEntry`
- `Es2kPrepareTunnelTermTableEntry` to `PrepareTunnelTermTableEntry`